### PR TITLE
remove all uses of import * as bsv

### DIFF
--- a/src/sdk/CertOps.ts
+++ b/src/sdk/CertOps.ts
@@ -1,26 +1,26 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String, Certificate as BsvCertificate, CertificateFieldNameUnder50Bytes, PubKeyHex, WalletCertificate, WalletInterface, WalletProtocol } from '@bsv/sdk'
 import { getIdentityKey, sdk } from '../index.client'
 import { SymmetricKey, Utils } from "@bsv/sdk";
 import { WERR_INVALID_OPERATION } from './WERR_errors';
 
-export class CertOps extends bsv.Certificate {
-    _keyring?: Record<bsv.CertificateFieldNameUnder50Bytes, string>
-    _encryptedFields?: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>
-    _decryptedFields?: Record<bsv.CertificateFieldNameUnder50Bytes, string>
+export class CertOps extends BsvCertificate {
+    _keyring?: Record<CertificateFieldNameUnder50Bytes, string>
+    _encryptedFields?: Record<CertificateFieldNameUnder50Bytes, Base64String>
+    _decryptedFields?: Record<CertificateFieldNameUnder50Bytes, string>
 
     constructor(
-        public wallet: bsv.WalletInterface,
-        wc: bsv.WalletCertificate,
+        public wallet: WalletInterface,
+        wc: WalletCertificate,
     ) {
         super(wc.type, wc.serialNumber, wc.subject, wc.certifier, wc.revocationOutpoint, wc.fields, wc.signature)
     }
 
     static async fromCounterparty(
-        wallet: bsv.WalletInterface,
+        wallet: WalletInterface,
         e: {
-            certificate: bsv.WalletCertificate,
-            keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string>,
-            counterparty: bsv.PubKeyHex
+            certificate: WalletCertificate,
+            keyring: Record<CertificateFieldNameUnder50Bytes, string>,
+            counterparty: PubKeyHex
         }
     )
     : Promise<CertOps>
@@ -35,8 +35,8 @@ export class CertOps extends bsv.Certificate {
     }
 
     static async fromCertifier(
-        wallet: bsv.WalletInterface,
-        e: { certificate: bsv.WalletCertificate, keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string> }
+        wallet: WalletInterface,
+        e: { certificate: WalletCertificate, keyring: Record<CertificateFieldNameUnder50Bytes, string> }
     )
     : Promise<CertOps>
     {
@@ -44,9 +44,9 @@ export class CertOps extends bsv.Certificate {
     }
 
     static async fromEncrypted(
-        wallet: bsv.WalletInterface,
-        wc: bsv.WalletCertificate,
-        keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string>
+        wallet: WalletInterface,
+        wc: WalletCertificate,
+        keyring: Record<CertificateFieldNameUnder50Bytes, string>
     )
     : Promise<CertOps>
     {
@@ -59,8 +59,8 @@ export class CertOps extends bsv.Certificate {
     }
 
     static async fromDecrypted(
-        wallet: bsv.WalletInterface,
-        wc: bsv.WalletCertificate
+        wallet: WalletInterface,
+        wc: WalletCertificate
     ) : Promise<CertOps>
     {
         const c = new CertOps(wallet, wc);
@@ -69,20 +69,20 @@ export class CertOps extends bsv.Certificate {
         return c
     }
 
-    static copyFields<T>(fields: Record<bsv.CertificateFieldNameUnder50Bytes, T>) : Record<bsv.CertificateFieldNameUnder50Bytes, T> {
-        const copy: Record<bsv.CertificateFieldNameUnder50Bytes, T> = {}
+    static copyFields<T>(fields: Record<CertificateFieldNameUnder50Bytes, T>) : Record<CertificateFieldNameUnder50Bytes, T> {
+        const copy: Record<CertificateFieldNameUnder50Bytes, T> = {}
         for (const [n, v] of Object.entries(fields))
             copy[n] = v
         return copy
     }
 
     static getProtocolForCertificateFieldEncryption(serialNumber: string, fieldName: string)
-    : { protocolID: bsv.WalletProtocol, keyID: string }
+    : { protocolID: WalletProtocol, keyID: string }
     {
         return { protocolID: [2, 'certificate field encryption'], keyID: `${serialNumber} ${fieldName}` }
     }
 
-    exportForSubject() : { certificate: bsv.WalletCertificate, keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string> }
+    exportForSubject() : { certificate: WalletCertificate, keyring: Record<CertificateFieldNameUnder50Bytes, string> }
     {
         if (!this._keyring || !this._encryptedFields || !this.signature || this.signature.length === 0)
             throw new WERR_INVALID_OPERATION(`Certificate must be encrypted and signed prior to export.`)
@@ -91,20 +91,20 @@ export class CertOps extends bsv.Certificate {
         return { certificate, keyring }
     }
 
-    toWalletCertificate() : bsv.WalletCertificate {
-        const wc: bsv.WalletCertificate = {
+    toWalletCertificate() : WalletCertificate {
+        const wc: WalletCertificate = {
             signature: '',
             ...this
         }
         return wc
     }
 
-    async encryptFields(counterparty: 'self' | bsv.PubKeyHex = 'self')
-    : Promise<{ fields: Record<bsv.CertificateFieldNameUnder50Bytes, string>, keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string>}>
+    async encryptFields(counterparty: 'self' | PubKeyHex = 'self')
+    : Promise<{ fields: Record<CertificateFieldNameUnder50Bytes, string>, keyring: Record<CertificateFieldNameUnder50Bytes, string>}>
     {
-        const fields: Record<bsv.CertificateFieldNameUnder50Bytes, string> = this._decryptedFields || this.fields
-        const encryptedFields: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String> = {}
-        const keyring: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String> = {}
+        const fields: Record<CertificateFieldNameUnder50Bytes, string> = this._decryptedFields || this.fields
+        const encryptedFields: Record<CertificateFieldNameUnder50Bytes, Base64String> = {}
+        const keyring: Record<CertificateFieldNameUnder50Bytes, Base64String> = {}
 
         for (const fieldName of Object.keys(fields)) {
             const fieldSymmetricKey = SymmetricKey.fromRandom()
@@ -124,10 +124,10 @@ export class CertOps extends bsv.Certificate {
         return { fields: encryptedFields, keyring}
     }
 
-    async decryptFields(counterparty?: bsv.PubKeyHex, keyring?: Record<bsv.CertificateFieldNameUnder50Bytes, string>): Promise<Record<bsv.CertificateFieldNameUnder50Bytes, string>> {
+    async decryptFields(counterparty?: PubKeyHex, keyring?: Record<CertificateFieldNameUnder50Bytes, string>): Promise<Record<CertificateFieldNameUnder50Bytes, string>> {
         keyring ||= this._keyring
-        const fields: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String> = this._encryptedFields || this.fields
-        const decryptedFields: Record<bsv.CertificateFieldNameUnder50Bytes, string> = {}
+        const fields: Record<CertificateFieldNameUnder50Bytes, Base64String> = this._encryptedFields || this.fields
+        const decryptedFields: Record<CertificateFieldNameUnder50Bytes, string> = {}
         if (!keyring)
             throw new sdk.WERR_INVALID_PARAMETER('keyring', 'valid')
 
@@ -154,13 +154,13 @@ export class CertOps extends bsv.Certificate {
 
     async exportForCounterparty(
         /** The incoming counterparty is who they are to us. */
-        counterparty: bsv.PubKeyHex,
-        fieldsToReveal: bsv.CertificateFieldNameUnder50Bytes[],
+        counterparty: PubKeyHex,
+        fieldsToReveal: CertificateFieldNameUnder50Bytes[],
     )
     : Promise<{
-        certificate: bsv.WalletCertificate,
-        keyring: Record<bsv.CertificateFieldNameUnder50Bytes, string>,
-        counterparty: bsv.PubKeyHex
+        certificate: WalletCertificate,
+        keyring: Record<CertificateFieldNameUnder50Bytes, string>,
+        counterparty: PubKeyHex
     }>
     {
         if (!this._keyring || !this._encryptedFields || !this.signature || this.signature.length === 0)
@@ -177,18 +177,18 @@ export class CertOps extends bsv.Certificate {
     * for the verifier's identity key. The resulting certificate structure includes only the fields intended to be
     * revealed and a verifier-specific keyring for field decryption.
     *
-    * @param {bsv.PubKeyHex} verifierIdentityKey - The public identity key of the verifier who will receive access to the specified fields.
-    * @param {bsv.CertificateFieldNameUnder50Bytes[]} fieldsToReveal - An array of field names to be revealed to the verifier. Must be a subset of the certificate's fields.
-    * @returns {Promise<Record<bsv.CertificateFieldNameUnder50Bytes[], bsv.Base64String>} - A new certificate structure containing the original encrypted fields, the verifier-specific field decryption keyring, and essential certificate metadata.
+    * @param {PubKeyHex} verifierIdentityKey - The public identity key of the verifier who will receive access to the specified fields.
+    * @param {CertificateFieldNameUnder50Bytes[]} fieldsToReveal - An array of field names to be revealed to the verifier. Must be a subset of the certificate's fields.
+    * @returns {Promise<Record<CertificateFieldNameUnder50Bytes[], Base64String>} - A new certificate structure containing the original encrypted fields, the verifier-specific field decryption keyring, and essential certificate metadata.
     * @throws {WERR_INVALID_PARAMETER} Throws an error if:
     *   - fieldsToReveal is empty or a field in `fieldsToReveal` does not exist in the certificate.
     *   - The decrypted master field key fails to decrypt the corresponding field (indicating an invalid key).
     */
     async createKeyringForVerifier(
-        verifierIdentityKey: bsv.PubKeyHex,
-        fieldsToReveal: bsv.CertificateFieldNameUnder50Bytes[]
+        verifierIdentityKey: PubKeyHex,
+        fieldsToReveal: CertificateFieldNameUnder50Bytes[]
     )
-    : Promise<Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>>
+    : Promise<Record<CertificateFieldNameUnder50Bytes, Base64String>>
     {
         if (!this._keyring || !this._encryptedFields)
             throw new sdk.WERR_INVALID_OPERATION(`certificate must be encrypted`)

--- a/src/sdk/WalletError.ts
+++ b/src/sdk/WalletError.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { ErrorCodeString10To40Bytes, ErrorDescriptionString20To200Bytes } from '@bsv/sdk'
 import { sdk } from "../index.client"
 import { WalletErrorObject } from "./Wallet.interfaces"
 
@@ -29,14 +29,14 @@ export class WalletError extends Error implements WalletErrorObject {
   /**
      * Error class compatible accessor for  `code`.
      */
-  get code (): bsv.ErrorCodeString10To40Bytes { return this.name }
-  set code (v: bsv.ErrorCodeString10To40Bytes) { this.name = v }
+  get code (): ErrorCodeString10To40Bytes { return this.name }
+  set code (v: ErrorCodeString10To40Bytes) { this.name = v }
 
   /**
      * Error class compatible accessor for `description`.
      */
-  get description (): bsv.ErrorDescriptionString20To200Bytes { return this.message }
-  set description (v: bsv.ErrorDescriptionString20To200Bytes) { this.message = v }
+  get description (): ErrorDescriptionString20To200Bytes { return this.message }
+  set description (v: ErrorDescriptionString20To200Bytes) { this.message = v }
 
   /**
    * Recovers all public fields from WalletError derived error classes and relevant Error derived errors.

--- a/src/sdk/WalletServices.interfaces.ts
+++ b/src/sdk/WalletServices.interfaces.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef, Transaction as BsvTransaction, ChainTracker, MerklePath } from '@bsv/sdk'
 import { sdk } from '../index.client'
 import { ChaintracksServiceClient } from '../services/chaintracker'
 /**
@@ -14,7 +14,7 @@ export interface WalletServices {
     /**
      * @returns standard `ChainTracker` service which requires `options.chaintracks` be valid.
      */
-    getChainTracker() : Promise<bsv.ChainTracker>
+    getChainTracker() : Promise<ChainTracker>
 
     /**
      * @returns serialized block header for height on active chain
@@ -90,7 +90,7 @@ export interface WalletServices {
      * @param chain 
      * @returns
      */
-    postTxs(beef: bsv.Beef, txids: string[]): Promise<PostTxsResult[]>
+    postTxs(beef: Beef, txids: string[]): Promise<PostTxsResult[]>
 
     /**
      * 
@@ -99,7 +99,7 @@ export interface WalletServices {
      * @param chain 
      * @returns
      */
-    postBeef(beef: bsv.Beef, txids: string[]): Promise<PostBeefResult[]>
+    postBeef(beef: Beef, txids: string[]): Promise<PostBeefResult[]>
 
     /**
      * Attempts to determine the UTXO status of a transaction output.
@@ -127,7 +127,7 @@ export interface WalletServices {
      * @returns whether the locktime value allows the transaction to be mined at the current chain height
      * @param txOrLockTime either a bitcoin locktime value or hex, binary, un-encoded Transaction
      */
-    nLockTimeIsFinal(txOrLockTime: string | number[] | bsv.Transaction | number): Promise<boolean>
+    nLockTimeIsFinal(txOrLockTime: string | number[] | BsvTransaction | number): Promise<boolean>
 }
 
 export type GetUtxoStatusOutputFormat = 'hashLE' | 'hashBE' | 'script'
@@ -192,7 +192,7 @@ export interface GetMerklePathResult {
      * Multiple proofs may be returned when a transaction also appears in
      * one or more orphaned blocks
      */
-    merklePath?: bsv.MerklePath
+    merklePath?: MerklePath
 
     header?: BlockHeader
 
@@ -219,7 +219,7 @@ export interface PostTxResultForTxid {
 
     blockHash?: string
     blockHeight?: number
-    merklePath?: bsv.MerklePath
+    merklePath?: MerklePath
 
     data?: object
 }
@@ -359,8 +359,8 @@ export type GetMerklePathService = (txid: string, chain: sdk.Chain, services: Wa
 
 export type GetRawTxService = (txid: string, chain: sdk.Chain) => Promise<GetRawTxResult>
 
-export type PostTxsService = (beef: bsv.Beef, txids: string[], services: WalletServices) => Promise<PostTxsResult>
+export type PostTxsService = (beef: Beef, txids: string[], services: WalletServices) => Promise<PostTxsResult>
 
-export type PostBeefService = (beef: bsv.Beef, txids: string[], services: WalletServices) => Promise<PostBeefResult>
+export type PostBeefService = (beef: Beef, txids: string[], services: WalletServices) => Promise<PostBeefResult>
 
 export type UpdateFiatExchangeRateService = (targetCurrencies: string[], options: WalletServicesOptions) => Promise<FiatExchangeRates>

--- a/src/sdk/WalletSigner.interfaces.ts
+++ b/src/sdk/WalletSigner.interfaces.ts
@@ -1,30 +1,30 @@
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs, AbortActionResult, AcquireCertificateArgs, AcquireCertificateResult, CreateActionArgs, CreateActionResult, DiscoverByAttributesArgs, DiscoverByIdentityKeyArgs, DiscoverCertificatesResult, InternalizeActionArgs, InternalizeActionResult, KeyDeriverApi, ListActionsArgs, ListActionsResult, ListCertificatesArgs, ListCertificatesResult, ListOutputsArgs, ListOutputsResult, ProveCertificateArgs, ProveCertificateResult, RelinquishCertificateArgs, RelinquishCertificateResult, RelinquishOutputArgs, RelinquishOutputResult, SignActionArgs, SignActionResult } from '@bsv/sdk'
 import { sdk } from "../index.client";
 
 /**
  */
 export interface WalletSigner {
   chain: sdk.Chain
-  keyDeriver: bsv.KeyDeriverApi
+  keyDeriver: KeyDeriverApi
 
   setServices(v: sdk.WalletServices) : void
   getServices() : sdk.WalletServices
   getStorageIdentity(): StorageIdentity
 
-  listActions(args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult>
-  listOutputs(args: bsv.ListOutputsArgs, knwonTxids: string[]): Promise<bsv.ListOutputsResult>
-  createAction(args: bsv.CreateActionArgs): Promise<bsv.CreateActionResult>
-  signAction(args: bsv.SignActionArgs): Promise<bsv.SignActionResult>
-  abortAction(args: bsv.AbortActionArgs): Promise<bsv.AbortActionResult>
-  internalizeAction(args: bsv.InternalizeActionArgs): Promise<bsv.InternalizeActionResult>
-  relinquishOutput(args: bsv.RelinquishOutputArgs) : Promise<bsv.RelinquishOutputResult>
+  listActions(args: ListActionsArgs): Promise<ListActionsResult>
+  listOutputs(args: ListOutputsArgs, knwonTxids: string[]): Promise<ListOutputsResult>
+  createAction(args: CreateActionArgs): Promise<CreateActionResult>
+  signAction(args: SignActionArgs): Promise<SignActionResult>
+  abortAction(args: AbortActionArgs): Promise<AbortActionResult>
+  internalizeAction(args: InternalizeActionArgs): Promise<InternalizeActionResult>
+  relinquishOutput(args: RelinquishOutputArgs) : Promise<RelinquishOutputResult>
 
-  acquireDirectCertificate(args: bsv.AcquireCertificateArgs) : Promise<bsv.AcquireCertificateResult>
-  listCertificates(args: bsv.ListCertificatesArgs) : Promise<bsv.ListCertificatesResult>
-  proveCertificate(args: bsv.ProveCertificateArgs): Promise<bsv.ProveCertificateResult>
-  relinquishCertificate(args: bsv.RelinquishCertificateArgs): Promise<bsv.RelinquishCertificateResult>
-  discoverByIdentityKey(args: bsv.DiscoverByIdentityKeyArgs): Promise<bsv.DiscoverCertificatesResult>
-  discoverByAttributes(args: bsv.DiscoverByAttributesArgs): Promise<bsv.DiscoverCertificatesResult>
+  acquireDirectCertificate(args: AcquireCertificateArgs) : Promise<AcquireCertificateResult>
+  listCertificates(args: ListCertificatesArgs) : Promise<ListCertificatesResult>
+  proveCertificate(args: ProveCertificateArgs): Promise<ProveCertificateResult>
+  relinquishCertificate(args: RelinquishCertificateArgs): Promise<RelinquishCertificateResult>
+  discoverByIdentityKey(args: DiscoverByIdentityKeyArgs): Promise<DiscoverCertificatesResult>
+  discoverByAttributes(args: DiscoverByAttributesArgs): Promise<DiscoverCertificatesResult>
 
   getChain(): Promise<sdk.Chain>
   getClientChangeKeyPair(): KeyPair;

--- a/src/sdk/WalletStorage.interfaces.ts
+++ b/src/sdk/WalletStorage.interfaces.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs, AbortActionResult, Beef, InternalizeActionArgs, InternalizeActionResult, ListActionsArgs, ListActionsResult, ListCertificatesResult, ListOutputsArgs, ListOutputsResult, RelinquishCertificateArgs, RelinquishOutputArgs, SendWithResult } from '@bsv/sdk'
 import { sdk, table } from "../index.client";
 
 /**
@@ -28,24 +28,24 @@ export interface WalletStorage {
 
    findOrInsertUser(identityKey: string) : Promise<{ user: table.User, isNew: boolean}>
 
-   abortAction(args: bsv.AbortActionArgs): Promise<bsv.AbortActionResult>
+   abortAction(args: AbortActionArgs): Promise<AbortActionResult>
    createAction(args: sdk.ValidCreateActionArgs): Promise<sdk.StorageCreateActionResult>
    processAction(args: sdk.StorageProcessActionArgs): Promise<sdk.StorageProcessActionResults>
-   internalizeAction(args: bsv.InternalizeActionArgs) : Promise<bsv.InternalizeActionResult>
+   internalizeAction(args: InternalizeActionArgs) : Promise<InternalizeActionResult>
 
    findCertificates(args: sdk.FindCertificatesArgs ): Promise<table.Certificate[]>
    findOutputBaskets(args: sdk.FindOutputBasketsArgs ): Promise<table.OutputBasket[]>
    findOutputs(args: sdk.FindOutputsArgs ): Promise<table.Output[]>
    findProvenTxReqs(args: sdk.FindProvenTxReqsArgs): Promise<table.ProvenTxReq[]>
 
-   listActions(args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult>
-   listCertificates(args: sdk.ValidListCertificatesArgs): Promise<bsv.ListCertificatesResult>
-   listOutputs(args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult>
+   listActions(args: ListActionsArgs): Promise<ListActionsResult>
+   listCertificates(args: sdk.ValidListCertificatesArgs): Promise<ListCertificatesResult>
+   listOutputs(args: ListOutputsArgs): Promise<ListOutputsResult>
 
    insertCertificate(certificate: table.CertificateX): Promise<number>
 
-   relinquishCertificate(args: bsv.RelinquishCertificateArgs) : Promise<number>
-   relinquishOutput(args: bsv.RelinquishOutputArgs) : Promise<number>
+   relinquishCertificate(args: RelinquishCertificateArgs) : Promise<number>
+   relinquishOutput(args: RelinquishOutputArgs) : Promise<number>
 
 }
 
@@ -77,15 +77,15 @@ export interface WalletStorageWriter extends WalletStorageReader {
 
    findOrInsertUser(identityKey: string) : Promise<{ user: table.User, isNew: boolean}>
 
-   abortAction(auth: sdk.AuthId, args: bsv.AbortActionArgs): Promise<bsv.AbortActionResult>
+   abortAction(auth: sdk.AuthId, args: AbortActionArgs): Promise<AbortActionResult>
    createAction(auth: sdk.AuthId, args: sdk.ValidCreateActionArgs): Promise<sdk.StorageCreateActionResult>
    processAction(auth: sdk.AuthId, args: sdk.StorageProcessActionArgs): Promise<sdk.StorageProcessActionResults>
-   internalizeAction(auth: sdk.AuthId, args: bsv.InternalizeActionArgs) : Promise<bsv.InternalizeActionResult>
+   internalizeAction(auth: sdk.AuthId, args: InternalizeActionArgs) : Promise<InternalizeActionResult>
 
    insertCertificateAuth(auth: sdk.AuthId, certificate: table.CertificateX): Promise<number>
 
-   relinquishCertificate(auth: sdk.AuthId, args: bsv.RelinquishCertificateArgs) : Promise<number>
-   relinquishOutput(auth: sdk.AuthId, args: bsv.RelinquishOutputArgs) : Promise<number>
+   relinquishCertificate(auth: sdk.AuthId, args: RelinquishCertificateArgs) : Promise<number>
+   relinquishOutput(auth: sdk.AuthId, args: RelinquishOutputArgs) : Promise<number>
 }
 
 export interface WalletStorageReader {
@@ -99,9 +99,9 @@ export interface WalletStorageReader {
    findOutputsAuth(auth: sdk.AuthId, args: sdk.FindOutputsArgs ): Promise<table.Output[]>
    findProvenTxReqs(args: sdk.FindProvenTxReqsArgs): Promise<table.ProvenTxReq[]>
 
-   listActions(auth: sdk.AuthId, args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult>
-   listCertificates(auth: sdk.AuthId, args: sdk.ValidListCertificatesArgs): Promise<bsv.ListCertificatesResult>
-   listOutputs(auth: sdk.AuthId, args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult>
+   listActions(auth: sdk.AuthId, args: ListActionsArgs): Promise<ListActionsResult>
+   listCertificates(auth: sdk.AuthId, args: sdk.ValidListCertificatesArgs): Promise<ListCertificatesResult>
+   listOutputs(auth: sdk.AuthId, args: ListOutputsArgs): Promise<ListOutputsResult>
 }
 
 export interface AuthId {
@@ -188,7 +188,7 @@ export interface StorageProcessActionArgs {
 }
 
 export interface StorageProcessActionResults {
-   sendWithResults?: bsv.SendWithResult[]
+   sendWithResults?: SendWithResult[]
    log?: string
 }
 
@@ -246,7 +246,7 @@ export interface StorageGetBeefOptions {
    /** list of txids to be included as txidOnly if referenced. Validity is known to caller. */
    knownTxids?: string[]
    /** optional. If defined, raw transactions and merkle paths required by txid are merged to this instance and returned. Otherwise a new Beef is constructed and returned. */
-   mergeToBeef?: bsv.Beef | number[]
+   mergeToBeef?: Beef | number[]
    /** optional. Default is false. `dojo.storage` is used for raw transaction and merkle proof lookup */
    ignoreStorage?: boolean
    /** optional. Default is false. `dojo.getServices` is used for raw transaction and merkle proof lookup */

--- a/src/sdk/validationHelpers.ts
+++ b/src/sdk/validationHelpers.ts
@@ -1,5 +1,4 @@
-import * as bsv from '@bsv/sdk'
-import { Utils } from "@bsv/sdk";
+import { AbortActionArgs, AcquireCertificateArgs, AcquisitionProtocol, AtomicBEEF, Base64String, BasketInsertion, BasketStringUnder300Bytes, BEEF, BooleanDefaultFalse, BooleanDefaultTrue, CertificateFieldNameUnder50Bytes, CreateActionArgs, CreateActionInput, CreateActionOptions, CreateActionOutput, DescriptionString5to50Bytes, DiscoverByAttributesArgs, DiscoverByIdentityKeyArgs, HexString, InternalizeActionArgs, InternalizeOutput, KeyringRevealer, LabelStringUnder300Bytes, ListActionsArgs, ListCertificatesArgs, ListOutputsArgs, OutpointString, OutputTagStringUnder300Bytes, PositiveInteger, PositiveIntegerDefault10Max10000, PositiveIntegerOrZero, ProveCertificateArgs, PubKeyHex, RelinquishCertificateArgs, RelinquishOutputArgs, SatoshiValue, SignActionArgs, SignActionOptions, SignActionSpend, TrustSelf, TXIDHexString, Utils, WalletPayment } from "@bsv/sdk";
 import { sdk } from "../index.client";
 import { OutPoint } from "./types";
 
@@ -153,13 +152,13 @@ export interface ValidWalletSignerArgs {
 
 export interface ValidCreateActionInput {
   outpoint: OutPoint
-  inputDescription: bsv.DescriptionString5to50Bytes
-  sequenceNumber: bsv.PositiveIntegerOrZero
-  unlockingScript?: bsv.HexString
-  unlockingScriptLength: bsv.PositiveInteger
+  inputDescription: DescriptionString5to50Bytes
+  sequenceNumber: PositiveIntegerOrZero
+  unlockingScript?: HexString
+  unlockingScriptLength: PositiveInteger
 }
 
-export function validateCreateActionInput(i: bsv.CreateActionInput): ValidCreateActionInput {
+export function validateCreateActionInput(i: CreateActionInput): ValidCreateActionInput {
     if (i.unlockingScript === undefined && i.unlockingScriptLength === undefined)
         throw new sdk.WERR_INVALID_PARAMETER('unlockingScript, unlockingScriptLength', `at least one valid value.`)
     const unlockingScript = validateOptionalHexString(i.unlockingScript, 'unlockingScript')
@@ -177,15 +176,15 @@ export function validateCreateActionInput(i: bsv.CreateActionInput): ValidCreate
 }
 
 export interface ValidCreateActionOutput {
-  lockingScript: bsv.HexString
-  satoshis: bsv.SatoshiValue
-  outputDescription: bsv.DescriptionString5to50Bytes
-  basket?: bsv.BasketStringUnder300Bytes
+  lockingScript: HexString
+  satoshis: SatoshiValue
+  outputDescription: DescriptionString5to50Bytes
+  basket?: BasketStringUnder300Bytes
   customInstructions?: string
-  tags: bsv.BasketStringUnder300Bytes[]
+  tags: BasketStringUnder300Bytes[]
 }
 
-export function validateCreateActionOutput(o: bsv.CreateActionOutput): ValidCreateActionOutput {
+export function validateCreateActionOutput(o: CreateActionOutput): ValidCreateActionOutput {
     const vo: ValidCreateActionOutput = {
         lockingScript: validateHexString(o.lockingScript, 'lockingScript'),
         satoshis: validateSatoshis(o.satoshis, 'satoshis'),
@@ -203,7 +202,7 @@ export function validateCreateActionOutput(o: bsv.CreateActionOutput): ValidCrea
  * Set all possibly undefined arrays to empty arrays.
  * Convert string outpoints to `{ txid: string, vout: number }`
  */
-export function validateCreateActionOptions(options?: bsv.CreateActionOptions) : ValidCreateActionOptions {
+export function validateCreateActionOptions(options?: CreateActionOptions) : ValidCreateActionOptions {
   const o = options || {}
   const vo: ValidCreateActionOptions = {
     signAndProcess: defaultTrue(o.signAndProcess),
@@ -219,16 +218,16 @@ export function validateCreateActionOptions(options?: bsv.CreateActionOptions) :
 }
 
 export interface ValidProcessActionOptions {
-  acceptDelayedBroadcast: bsv.BooleanDefaultTrue
-  returnTXIDOnly: bsv.BooleanDefaultFalse
-  noSend: bsv.BooleanDefaultFalse
-  sendWith: bsv.TXIDHexString[]
+  acceptDelayedBroadcast: BooleanDefaultTrue
+  returnTXIDOnly: BooleanDefaultFalse
+  noSend: BooleanDefaultFalse
+  sendWith: TXIDHexString[]
 }
 
 export interface ValidCreateActionOptions extends ValidProcessActionOptions {
   signAndProcess: boolean
-  trustSelf?: bsv.TrustSelf
-  knownTxids: bsv.TXIDHexString[]
+  trustSelf?: TrustSelf
+  knownTxids: TXIDHexString[]
   noSendChange: OutPoint[]
   randomizeOutputs: boolean
 }
@@ -237,7 +236,7 @@ export interface ValidSignActionOptions extends ValidProcessActionOptions {
   acceptDelayedBroadcast: boolean
   returnTXIDOnly: boolean
   noSend: boolean
-  sendWith: bsv.TXIDHexString[]
+  sendWith: TXIDHexString[]
 }
 
 export interface ValidProcessActionArgs extends ValidWalletSignerArgs {
@@ -253,8 +252,8 @@ export interface ValidProcessActionArgs extends ValidWalletSignerArgs {
 }
 
 export interface ValidCreateActionArgs extends ValidProcessActionArgs {
-  description: bsv.DescriptionString5to50Bytes
-  inputBEEF?: bsv.BEEF
+  description: DescriptionString5to50Bytes
+  inputBEEF?: BEEF
   inputs: sdk.ValidCreateActionInput[]
   outputs: sdk.ValidCreateActionOutput[]
   lockTime: number
@@ -267,13 +266,13 @@ export interface ValidCreateActionArgs extends ValidProcessActionArgs {
 }
 
 export interface ValidSignActionArgs extends ValidProcessActionArgs {
-  spends: Record<bsv.PositiveIntegerOrZero, bsv.SignActionSpend>
-  reference: bsv.Base64String
+  spends: Record<PositiveIntegerOrZero, SignActionSpend>
+  reference: Base64String
 
   options: sdk.ValidSignActionOptions
 }
 
-export function validateCreateActionArgs(args: bsv.CreateActionArgs) : ValidCreateActionArgs {
+export function validateCreateActionArgs(args: CreateActionArgs) : ValidCreateActionArgs {
     const vargs: ValidCreateActionArgs = {
       description: validateStringLength(args.description, 'description', 5, 50),
       inputBEEF: args.inputBEEF,
@@ -307,7 +306,7 @@ export function validateCreateActionArgs(args: bsv.CreateActionArgs) : ValidCrea
  * Set all possibly undefined arrays to empty arrays.
  * Convert string outpoints to `{ txid: string, vout: number }`
  */
-export function validateSignActionOptions(options?: bsv.SignActionOptions) : ValidSignActionOptions {
+export function validateSignActionOptions(options?: SignActionOptions) : ValidSignActionOptions {
   const o = options || {}
   const vo: ValidSignActionOptions = {
     acceptDelayedBroadcast: defaultTrue(o.acceptDelayedBroadcast),
@@ -318,7 +317,7 @@ export function validateSignActionOptions(options?: bsv.SignActionOptions) : Val
   return vo
 }
 
-export function validateSignActionArgs(args: bsv.SignActionArgs) : ValidSignActionArgs {
+export function validateSignActionArgs(args: SignActionArgs) : ValidSignActionArgs {
     const vargs: ValidSignActionArgs = {
       spends: args.spends,
       reference: args.reference,
@@ -336,10 +335,10 @@ export function validateSignActionArgs(args: bsv.SignActionArgs) : ValidSignActi
 }
 
 export interface ValidAbortActionArgs extends ValidWalletSignerArgs {
-  reference: bsv.Base64String
+  reference: Base64String
 }
 
-export function validateAbortActionArgs(args: bsv.AbortActionArgs) : ValidAbortActionArgs {
+export function validateAbortActionArgs(args: AbortActionArgs) : ValidAbortActionArgs {
     const vargs: ValidAbortActionArgs = {
       reference: validateBase64String(args.reference, 'reference'),
     }
@@ -348,12 +347,12 @@ export function validateAbortActionArgs(args: bsv.AbortActionArgs) : ValidAbortA
 }
 
 export interface ValidWalletPayment {
-  derivationPrefix: bsv.Base64String
-  derivationSuffix: bsv.Base64String
-  senderIdentityKey: bsv.PubKeyHex
+  derivationPrefix: Base64String
+  derivationSuffix: Base64String
+  senderIdentityKey: PubKeyHex
 }
 
-export function validateWalletPayment(args?: bsv.WalletPayment) : ValidWalletPayment | undefined {
+export function validateWalletPayment(args?: WalletPayment) : ValidWalletPayment | undefined {
   if (args === undefined) return undefined
   const v: ValidWalletPayment = {
     derivationPrefix: validateBase64String(args.derivationPrefix, 'derivationPrefix'),
@@ -364,12 +363,12 @@ export function validateWalletPayment(args?: bsv.WalletPayment) : ValidWalletPay
 }
 
 export interface ValidBasketInsertion {
-  basket: bsv.BasketStringUnder300Bytes
+  basket: BasketStringUnder300Bytes
   customInstructions?: string
-  tags: bsv.BasketStringUnder300Bytes[]
+  tags: BasketStringUnder300Bytes[]
 }
 
-export function validateBasketInsertion(args?: bsv.BasketInsertion) : ValidBasketInsertion | undefined {
+export function validateBasketInsertion(args?: BasketInsertion) : ValidBasketInsertion | undefined {
   if (args === undefined) return undefined
   const v: ValidBasketInsertion = {
     basket: validateBasket(args.basket),
@@ -380,13 +379,13 @@ export function validateBasketInsertion(args?: bsv.BasketInsertion) : ValidBaske
 }
 
 export interface ValidInternalizeOutput {
-  outputIndex: bsv.PositiveIntegerOrZero
+  outputIndex: PositiveIntegerOrZero
   protocol: 'wallet payment' | 'basket insertion'
   paymentRemittance?: ValidWalletPayment
   insertionRemittance?: ValidBasketInsertion
 }
 
-export function validateInternalizeOutput(args: bsv.InternalizeOutput) : ValidInternalizeOutput {
+export function validateInternalizeOutput(args: InternalizeOutput) : ValidInternalizeOutput {
   if (args.protocol !== 'basket insertion' && args.protocol !== 'wallet payment')
     throw new sdk.WERR_INVALID_PARAMETER('protocol', `'basket insertion' or 'wallet payment'`)
   const v: ValidInternalizeOutput = {
@@ -399,11 +398,11 @@ export function validateInternalizeOutput(args: bsv.InternalizeOutput) : ValidIn
 }
 
 export interface ValidInternalizeActionArgs extends ValidWalletSignerArgs {
-  tx: bsv.AtomicBEEF,
-  outputs: bsv.InternalizeOutput[]
-  description: bsv.DescriptionString5to50Bytes
-  labels: bsv.LabelStringUnder300Bytes[]
-  seekPermission: bsv.BooleanDefaultTrue
+  tx: AtomicBEEF,
+  outputs: InternalizeOutput[]
+  description: DescriptionString5to50Bytes
+  labels: LabelStringUnder300Bytes[]
+  seekPermission: BooleanDefaultTrue
 }
 
 export function validateOriginator(s?: string) : string | undefined {
@@ -416,7 +415,7 @@ export function validateOriginator(s?: string) : string | undefined {
   }
 }
 
-export function validateInternalizeActionArgs(args: bsv.InternalizeActionArgs) : ValidInternalizeActionArgs {
+export function validateInternalizeActionArgs(args: InternalizeActionArgs) : ValidInternalizeActionArgs {
     const vargs: ValidInternalizeActionArgs = {
       tx: args.tx,
       outputs: args.outputs.map(o => validateInternalizeOutput(o)),
@@ -443,11 +442,11 @@ export function validateOutpointString(outpoint: string, name: string): string {
 }
 
 export interface ValidRelinquishOutputArgs extends ValidWalletSignerArgs {
-  basket: bsv.BasketStringUnder300Bytes
-  output: bsv.OutpointString
+  basket: BasketStringUnder300Bytes
+  output: OutpointString
 }
 
-export function validateRelinquishOutputArgs(args: bsv.RelinquishOutputArgs) : ValidRelinquishOutputArgs {
+export function validateRelinquishOutputArgs(args: RelinquishOutputArgs) : ValidRelinquishOutputArgs {
     const vargs: ValidRelinquishOutputArgs = {
       basket: validateBasket(args.basket),
       output: validateOutpointString(args.output, 'output'),
@@ -457,12 +456,12 @@ export function validateRelinquishOutputArgs(args: bsv.RelinquishOutputArgs) : V
 }
 
 export interface ValidRelinquishCertificateArgs extends ValidWalletSignerArgs {
-  type: bsv.Base64String
-  serialNumber: bsv.Base64String
-  certifier: bsv.PubKeyHex
+  type: Base64String
+  serialNumber: Base64String
+  certifier: PubKeyHex
 }
 
-export function validateRelinquishCertificateArgs(args: bsv.RelinquishCertificateArgs) : ValidRelinquishCertificateArgs {
+export function validateRelinquishCertificateArgs(args: RelinquishCertificateArgs) : ValidRelinquishCertificateArgs {
     const vargs: ValidRelinquishCertificateArgs = {
       type: validateBase64String(args.type, 'type'),
       serialNumber: validateBase64String(args.serialNumber, 'serialNumber'),
@@ -474,22 +473,22 @@ export function validateRelinquishCertificateArgs(args: bsv.RelinquishCertificat
 
 export interface ValidListCertificatesArgs extends ValidWalletSignerArgs {
   partial?: {
-    type?: bsv.Base64String
-    serialNumber?: bsv.Base64String
-    certifier?: bsv.PubKeyHex
-    subject?: bsv.PubKeyHex
-    revocationOutpoint?: bsv.OutpointString
-    signature?: bsv.HexString
+    type?: Base64String
+    serialNumber?: Base64String
+    certifier?: PubKeyHex
+    subject?: PubKeyHex
+    revocationOutpoint?: OutpointString
+    signature?: HexString
   }
-  certifiers: bsv.PubKeyHex[]
-  types: bsv.Base64String[]
-  limit: bsv.PositiveIntegerDefault10Max10000
-  offset: bsv.PositiveIntegerOrZero
-  privileged: bsv.BooleanDefaultFalse
-  privilegedReason?: bsv.DescriptionString5to50Bytes
+  certifiers: PubKeyHex[]
+  types: Base64String[]
+  limit: PositiveIntegerDefault10Max10000
+  offset: PositiveIntegerOrZero
+  privileged: BooleanDefaultFalse
+  privilegedReason?: DescriptionString5to50Bytes
 }
 
-export function validateListCertificatesArgs(args: bsv.ListCertificatesArgs) : ValidListCertificatesArgs {
+export function validateListCertificatesArgs(args: ListCertificatesArgs) : ValidListCertificatesArgs {
     const vargs: ValidListCertificatesArgs = {
       certifiers: defaultEmpty(args.certifiers.map(c => validateHexString(c.trim(), 'certifiers'))),
       types: defaultEmpty(args.types.map(t => validateBase64String(t.trim(), 'types'))),
@@ -503,26 +502,26 @@ export function validateListCertificatesArgs(args: bsv.ListCertificatesArgs) : V
 }
 
 export interface ValidAcquireCertificateArgs extends ValidWalletSignerArgs {
-  acquisitionProtocol: bsv.AcquisitionProtocol
+  acquisitionProtocol: AcquisitionProtocol
 
-  type: bsv.Base64String
-  serialNumber?: bsv.Base64String
-  certifier: bsv.PubKeyHex
-  revocationOutpoint?: bsv.OutpointString
-  fields: Record<bsv.CertificateFieldNameUnder50Bytes, string>
-  signature?: bsv.HexString
+  type: Base64String
+  serialNumber?: Base64String
+  certifier: PubKeyHex
+  revocationOutpoint?: OutpointString
+  fields: Record<CertificateFieldNameUnder50Bytes, string>
+  signature?: HexString
 
   certifierUrl?: string
 
-  keyringRevealer?: bsv.KeyringRevealer
-  keyringForSubject?: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>
+  keyringRevealer?: KeyringRevealer
+  keyringForSubject?: Record<CertificateFieldNameUnder50Bytes, Base64String>
 
   privileged: boolean
-  privilegedReason?: bsv.DescriptionString5to50Bytes
+  privilegedReason?: DescriptionString5to50Bytes
 }
 
-function validateCertificateFields(fields: Record<bsv.CertificateFieldNameUnder50Bytes, string>):
-Record<bsv.CertificateFieldNameUnder50Bytes, string>
+function validateCertificateFields(fields: Record<CertificateFieldNameUnder50Bytes, string>):
+Record<CertificateFieldNameUnder50Bytes, string>
 {
   for (const fieldName of Object.keys(fields)) {
     validateStringLength(fieldName, 'field name', 1, 50)
@@ -530,19 +529,19 @@ Record<bsv.CertificateFieldNameUnder50Bytes, string>
   return fields
 }
 
-function validateKeyringRevealer(kr: bsv.KeyringRevealer, name: string) : bsv.KeyringRevealer
+function validateKeyringRevealer(kr: KeyringRevealer, name: string) : KeyringRevealer
 {
   if (kr === 'certifier') return kr
   return validateHexString(kr, name)
 }
 
-function validateOptionalKeyringRevealer(kr: bsv.KeyringRevealer | undefined, name: string) : bsv.KeyringRevealer | undefined
+function validateOptionalKeyringRevealer(kr: KeyringRevealer | undefined, name: string) : KeyringRevealer | undefined
 {
   if (kr === undefined) return undefined
   return validateKeyringRevealer(kr, name)
 }
 
-function validateKeyringForSubject(kr: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>, name: string) : Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>
+function validateKeyringForSubject(kr: Record<CertificateFieldNameUnder50Bytes, Base64String>, name: string) : Record<CertificateFieldNameUnder50Bytes, Base64String>
 {
   for (const fn of Object.keys(kr)) {
     validateStringLength(fn, `${name} field name`, 1, 50);
@@ -551,7 +550,7 @@ function validateKeyringForSubject(kr: Record<bsv.CertificateFieldNameUnder50Byt
   return kr
 }
 
-function validateOptionalKeyringForSubject(kr: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String> | undefined, name: string) : Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String> | undefined {
+function validateOptionalKeyringForSubject(kr: Record<CertificateFieldNameUnder50Bytes, Base64String> | undefined, name: string) : Record<CertificateFieldNameUnder50Bytes, Base64String> | undefined {
   if (kr === undefined) return undefined
   return validateKeyringForSubject(kr, name)
 }
@@ -562,7 +561,7 @@ function validateOptionalKeyringForSubject(kr: Record<bsv.CertificateFieldNameUn
  * @param subject Must be valid for "direct" `acquisitionProtocol`. public key of the certificate subject.
  * @returns 
  */
-export async function validateAcquireCertificateArgs(args: bsv.AcquireCertificateArgs) : Promise<ValidAcquireCertificateArgs> {
+export async function validateAcquireCertificateArgs(args: AcquireCertificateArgs) : Promise<ValidAcquireCertificateArgs> {
   const vargs: ValidAcquireCertificateArgs = {
     acquisitionProtocol: args.acquisitionProtocol,
     type: validateBase64String(args.type, 'type'),
@@ -588,27 +587,27 @@ export async function validateAcquireCertificateArgs(args: bsv.AcquireCertificat
 }
 
 export interface ValidAcquireDirectCertificateArgs extends ValidWalletSignerArgs {
-  type: bsv.Base64String
-  serialNumber: bsv.Base64String
-  certifier: bsv.PubKeyHex
-  revocationOutpoint: bsv.OutpointString
-  fields: Record<bsv.CertificateFieldNameUnder50Bytes, string>
-  signature: bsv.HexString
+  type: Base64String
+  serialNumber: Base64String
+  certifier: PubKeyHex
+  revocationOutpoint: OutpointString
+  fields: Record<CertificateFieldNameUnder50Bytes, string>
+  signature: HexString
 
   /**
    * validated to an empty string, must be provided by wallet and must
    * match expectations of keyringForSubject
    */
-  subject: bsv.PubKeyHex
+  subject: PubKeyHex
 
-  keyringRevealer: bsv.KeyringRevealer
-  keyringForSubject: Record<bsv.CertificateFieldNameUnder50Bytes, bsv.Base64String>
+  keyringRevealer: KeyringRevealer
+  keyringForSubject: Record<CertificateFieldNameUnder50Bytes, Base64String>
 
   privileged: boolean
-  privilegedReason?: bsv.DescriptionString5to50Bytes
+  privilegedReason?: DescriptionString5to50Bytes
 }
 
-export function validateAcquireDirectCertificateArgs(args: bsv.AcquireCertificateArgs) : ValidAcquireDirectCertificateArgs {
+export function validateAcquireDirectCertificateArgs(args: AcquireCertificateArgs) : ValidAcquireDirectCertificateArgs {
   if (args.acquisitionProtocol !== 'direct') throw new sdk.WERR_INTERNAL('Only acquire direct certificate requests allowed here.')
   if (!args.serialNumber) throw new sdk.WERR_INVALID_PARAMETER('serialNumber', 'valid when acquisitionProtocol is "direct"')
   if (!args.signature) throw new sdk.WERR_INVALID_PARAMETER('signature', 'valid when acquisitionProtocol is "direct"')
@@ -634,20 +633,20 @@ export function validateAcquireDirectCertificateArgs(args: bsv.AcquireCertificat
 }
 
 export interface ValidProveCertificateArgs extends ValidWalletSignerArgs {
-  type?: bsv.Base64String
-  serialNumber?: bsv.Base64String
-  certifier?: bsv.PubKeyHex
-  subject?: bsv.PubKeyHex
-  revocationOutpoint?: bsv.OutpointString
-  signature?: bsv.HexString
+  type?: Base64String
+  serialNumber?: Base64String
+  certifier?: PubKeyHex
+  subject?: PubKeyHex
+  revocationOutpoint?: OutpointString
+  signature?: HexString
   
-  fieldsToReveal: bsv.CertificateFieldNameUnder50Bytes[]
-  verifier: bsv.PubKeyHex
+  fieldsToReveal: CertificateFieldNameUnder50Bytes[]
+  verifier: PubKeyHex
   privileged: boolean
-  privilegedReason?: bsv.DescriptionString5to50Bytes
+  privilegedReason?: DescriptionString5to50Bytes
 }
 
-export function validateProveCertificateArgs(args: bsv.ProveCertificateArgs)
+export function validateProveCertificateArgs(args: ProveCertificateArgs)
 : ValidProveCertificateArgs
 {
   if (args.privileged && !args.privilegedReason) throw new sdk.WERR_INVALID_PARAMETER('privilegedReason', `valid when 'privileged' is true `)
@@ -668,13 +667,13 @@ export function validateProveCertificateArgs(args: bsv.ProveCertificateArgs)
 }
 
 export interface ValidDiscoverByIdentityKeyArgs extends ValidWalletSignerArgs {
-  identityKey: bsv.PubKeyHex
-  limit: bsv.PositiveIntegerDefault10Max10000
-  offset: bsv.PositiveIntegerOrZero
+  identityKey: PubKeyHex
+  limit: PositiveIntegerDefault10Max10000
+  offset: PositiveIntegerOrZero
   seekPermission: boolean
 }
 
-export function validateDiscoverByIdentityKeyArgs(args: bsv.DiscoverByIdentityKeyArgs)
+export function validateDiscoverByIdentityKeyArgs(args: DiscoverByIdentityKeyArgs)
 : ValidDiscoverByIdentityKeyArgs
 {
   const vargs: ValidDiscoverByIdentityKeyArgs = {
@@ -687,14 +686,14 @@ export function validateDiscoverByIdentityKeyArgs(args: bsv.DiscoverByIdentityKe
 }
 
 export interface ValidDiscoverByAttributesArgs extends ValidWalletSignerArgs {
-  attributes: Record<bsv.CertificateFieldNameUnder50Bytes, string>
-  limit: bsv.PositiveIntegerDefault10Max10000
-  offset: bsv.PositiveIntegerOrZero
+  attributes: Record<CertificateFieldNameUnder50Bytes, string>
+  limit: PositiveIntegerDefault10Max10000
+  offset: PositiveIntegerOrZero
   seekPermission: boolean
 }
 
-function validateAttributes(attributes: Record<bsv.CertificateFieldNameUnder50Bytes, string>):
-Record<bsv.CertificateFieldNameUnder50Bytes, string>
+function validateAttributes(attributes: Record<CertificateFieldNameUnder50Bytes, string>):
+Record<CertificateFieldNameUnder50Bytes, string>
 {
   for (const fieldName of Object.keys(attributes)) {
     validateStringLength(fieldName, `field name ${fieldName}`, 1, 50)
@@ -702,7 +701,7 @@ Record<bsv.CertificateFieldNameUnder50Bytes, string>
   return attributes
 }
 
-export function validateDiscoverByAttributesArgs(args: bsv.DiscoverByAttributesArgs)
+export function validateDiscoverByAttributesArgs(args: DiscoverByAttributesArgs)
 : ValidDiscoverByAttributesArgs
 {
   const vargs: ValidDiscoverByAttributesArgs = {
@@ -715,17 +714,17 @@ export function validateDiscoverByAttributesArgs(args: bsv.DiscoverByAttributesA
 }
 
 export interface ValidListOutputsArgs extends ValidWalletSignerArgs {
-  basket: bsv.BasketStringUnder300Bytes
-  tags: bsv.OutputTagStringUnder300Bytes[]
+  basket: BasketStringUnder300Bytes
+  tags: OutputTagStringUnder300Bytes[]
   tagQueryMode: 'all' | 'any'
   includeLockingScripts: boolean,
   includeTransactions: boolean,
-  includeCustomInstructions: bsv.BooleanDefaultFalse
-  includeTags: bsv.BooleanDefaultFalse
-  includeLabels: bsv.BooleanDefaultFalse
-  limit: bsv.PositiveIntegerDefault10Max10000
-  offset: bsv.PositiveIntegerOrZero
-  seekPermission: bsv.BooleanDefaultTrue
+  includeCustomInstructions: BooleanDefaultFalse
+  includeTags: BooleanDefaultFalse
+  includeLabels: BooleanDefaultFalse
+  limit: PositiveIntegerDefault10Max10000
+  offset: PositiveIntegerOrZero
+  seekPermission: BooleanDefaultTrue
   knownTxids: string[]
 }
 
@@ -742,7 +741,7 @@ export interface ValidListOutputsArgs extends ValidWalletSignerArgs {
    * @param {PositiveIntegerOrZero} [args.offset] - Optional. Number of outputs to skip before starting to return results.
    * @param {BooleanDefaultTrue} [args.seekPermission] — Optional. Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
  */
-export function validateListOutputsArgs(args: bsv.ListOutputsArgs) : ValidListOutputsArgs {
+export function validateListOutputsArgs(args: ListOutputsArgs) : ValidListOutputsArgs {
     let tagQueryMode: 'any' | 'all'
     if (args.tagQueryMode === undefined || args.tagQueryMode === 'any')
       tagQueryMode = 'any'
@@ -770,33 +769,33 @@ export function validateListOutputsArgs(args: bsv.ListOutputsArgs) : ValidListOu
 }
 
 export interface ValidListActionsArgs extends ValidWalletSignerArgs {
-  labels: bsv.LabelStringUnder300Bytes[]
+  labels: LabelStringUnder300Bytes[]
   labelQueryMode: 'any' | 'all'
-  includeLabels: bsv.BooleanDefaultFalse
-  includeInputs: bsv.BooleanDefaultFalse
-  includeInputSourceLockingScripts: bsv.BooleanDefaultFalse
-  includeInputUnlockingScripts: bsv.BooleanDefaultFalse
-  includeOutputs: bsv.BooleanDefaultFalse
-  includeOutputLockingScripts: bsv.BooleanDefaultFalse
-  limit: bsv.PositiveIntegerDefault10Max10000
-  offset: bsv.PositiveIntegerOrZero
-  seekPermission: bsv.BooleanDefaultTrue
+  includeLabels: BooleanDefaultFalse
+  includeInputs: BooleanDefaultFalse
+  includeInputSourceLockingScripts: BooleanDefaultFalse
+  includeInputUnlockingScripts: BooleanDefaultFalse
+  includeOutputs: BooleanDefaultFalse
+  includeOutputLockingScripts: BooleanDefaultFalse
+  limit: PositiveIntegerDefault10Max10000
+  offset: PositiveIntegerOrZero
+  seekPermission: BooleanDefaultTrue
 }
 
 /**
-   * @param {bsv.LabelStringUnder300Bytes[]} args.labels - An array of labels used to filter actions.
+   * @param {LabelStringUnder300Bytes[]} args.labels - An array of labels used to filter actions.
    * @param {'any' | 'all'} [args.labelQueryMode] - Optional. Specifies how to match labels (default is any which matches any of the labels).
-   * @param {bsv.BooleanDefaultFalse} [args.includeLabels] - Optional. Whether to include transaction labels in the result set.
-   * @param {bsv.BooleanDefaultFalse} [args.includeInputs] - Optional. Whether to include input details in the result set.
-   * @param {bsv.BooleanDefaultFalse} [args.includeInputSourceLockingScripts] - Optional. Whether to include input source locking scripts in the result set.
-   * @param {bsv.BooleanDefaultFalse} [args.includeInputUnlockingScripts] - Optional. Whether to include input unlocking scripts in the result set.
-   * @param {bsv.BooleanDefaultFalse} [args.includeOutputs] - Optional. Whether to include output details in the result set.
-   * @param {bsv.BooleanDefaultFalse} [args.includeOutputLockingScripts] - Optional. Whether to include output locking scripts in the result set.
-   * @param {bsv.PositiveIntegerDefault10Max10000} [args.limit] - Optional. The maximum number of transactions to retrieve.
-   * @param {bsv.PositiveIntegerOrZero} [args.offset] - Optional. Number of transactions to skip before starting to return the results.
-   * @param {bsv.BooleanDefaultTrue} [args.seekPermission] — Optional. Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
+   * @param {BooleanDefaultFalse} [args.includeLabels] - Optional. Whether to include transaction labels in the result set.
+   * @param {BooleanDefaultFalse} [args.includeInputs] - Optional. Whether to include input details in the result set.
+   * @param {BooleanDefaultFalse} [args.includeInputSourceLockingScripts] - Optional. Whether to include input source locking scripts in the result set.
+   * @param {BooleanDefaultFalse} [args.includeInputUnlockingScripts] - Optional. Whether to include input unlocking scripts in the result set.
+   * @param {BooleanDefaultFalse} [args.includeOutputs] - Optional. Whether to include output details in the result set.
+   * @param {BooleanDefaultFalse} [args.includeOutputLockingScripts] - Optional. Whether to include output locking scripts in the result set.
+   * @param {PositiveIntegerDefault10Max10000} [args.limit] - Optional. The maximum number of transactions to retrieve.
+   * @param {PositiveIntegerOrZero} [args.offset] - Optional. Number of transactions to skip before starting to return the results.
+   * @param {BooleanDefaultTrue} [args.seekPermission] — Optional. Whether to seek permission from the user for this operation if required. Default true, will return an error rather than proceed if set to false.
  */
-export function validateListActionsArgs(args: bsv.ListActionsArgs) : ValidListActionsArgs {
+export function validateListActionsArgs(args: ListActionsArgs) : ValidListActionsArgs {
     let labelQueryMode: 'any' | 'all'
     if (args.labelQueryMode === undefined || args.labelQueryMode === 'any')
       labelQueryMode = 'any'

--- a/src/services/Services.ts
+++ b/src/services/Services.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Transaction as BsvTransaction, Beef, ChainTracker, Utils } from '@bsv/sdk'
 import { asArray, asString, doubleSha256BE, sdk, sha256Hash, wait } from '../index.client'
 import { ServiceCollection } from './ServiceCollection'
 
@@ -50,7 +50,7 @@ export class Services implements sdk.WalletServices {
             .add({ name: 'exchangeratesapi', service: updateExchangeratesapi })
     }
 
-    async getChainTracker(): Promise<bsv.ChainTracker> {
+    async getChainTracker(): Promise<ChainTracker> {
         if (!this.options.chaintracks)
             throw new sdk.WERR_INVALID_PARAMETER('options.chaintracks', `valid to enable 'getChainTracker' service.`)
         return new ChaintracksChainTracker(this.chain, this.options.chaintracks)
@@ -110,7 +110,7 @@ export class Services implements sdk.WalletServices {
      * @param txids
      * @returns
      */
-    async postTxs(beef: bsv.Beef, txids: string[]): Promise<sdk.PostTxsResult[]> {
+    async postTxs(beef: Beef, txids: string[]): Promise<sdk.PostTxsResult[]> {
 
         const rs = await Promise.all(this.postTxsServices.allServices.map(async service => {
             const r = await service(beef, txids, this)
@@ -126,7 +126,7 @@ export class Services implements sdk.WalletServices {
      * @param chain 
      * @returns
      */
-    async postBeef(beef: bsv.Beef, txids: string[]): Promise<sdk.PostBeefResult[]> {
+    async postBeef(beef: Beef, txids: string[]): Promise<sdk.PostBeefResult[]> {
 
         let rs = await Promise.all(this.postBeefServices.allServices.map(async service => {
             const r = await service(beef, txids, this)
@@ -283,7 +283,7 @@ export class Services implements sdk.WalletServices {
         return r0
     }
 
-    async nLockTimeIsFinal(tx: string | number[] | bsv.Transaction | number): Promise<boolean> {
+    async nLockTimeIsFinal(tx: string | number[] | BsvTransaction | number): Promise<boolean> {
         const MAXINT = 0xffffffff
         const BLOCK_LIMIT = 500000000
 
@@ -293,12 +293,12 @@ export class Services implements sdk.WalletServices {
             nLockTime = tx
         else {
             if (typeof tx === 'string') {
-                tx = bsv.Transaction.fromHex(tx)
+                tx = BsvTransaction.fromHex(tx)
             } else if (Array.isArray(tx)) {
-                tx = bsv.Transaction.fromBinary(tx)
+                tx = BsvTransaction.fromBinary(tx)
             }
 
-            if (tx instanceof bsv.Transaction) {
+            if (tx instanceof BsvTransaction) {
                 if (tx.inputs.every(i => i.sequence === MAXINT)) {
                     return true
                 }
@@ -350,7 +350,7 @@ export function validateScriptHash(output: string, outputFormat?: sdk.GetUtxoSta
  * @publicbody
  */
 export function toBinaryBaseBlockHeader(header: sdk.BaseBlockHeader): number[] {
-    const writer = new bsv.Utils.Writer()
+    const writer = new Utils.Writer()
     writer.writeUInt32BE(header.version)
     writer.writeReverse(asArray(header.previousHash))
     writer.writeReverse(asArray(header.merkleRoot))

--- a/src/services/__tests/getMerklePath.test.ts
+++ b/src/services/__tests/getMerklePath.test.ts
@@ -1,4 +1,3 @@
-import * as bsv from '@bsv/sdk'
 import { Services } from "../../index.client"
 
 describe('getRawTx service tests', () => {

--- a/src/services/__tests/postBeef.test.ts
+++ b/src/services/__tests/postBeef.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef } from '@bsv/sdk'
 import { Services } from "../../index.client"
 
 describe('postBeef service tests', () => {
@@ -11,7 +11,7 @@ describe('postBeef service tests', () => {
 
         const txid = '9cce99686bc8621db439b7150dd5b3b269e4b0628fd75160222c417d6f2b95e4'
         const rawTx = await services.getRawTx(txid)
-        const beef = new bsv.Beef()
+        const beef = new Beef()
         beef.mergeRawTx(rawTx.rawTx!)
         const r = await services.postTxs(beef, [txid])
         expect(r).toBeTruthy()

--- a/src/services/__tests/postBeefbob1.test.ts
+++ b/src/services/__tests/postBeefbob1.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef } from '@bsv/sdk'
 import { Services } from '../../index.all'
 
 const BEEF_V1 = 4022206465 // 0100BEEF in LE order
@@ -27,7 +27,7 @@ describe.skip('postBeef service tests', () => {
     // Step 1: Test with Original BEEF V2
     const beefBinaryV2 = hexToBinary(beefV2HexStr)
     console.log('Testing BEEF V2...')
-    const beefV2 = bsv.Beef.fromBinary(beefBinaryV2)
+    const beefV2 = Beef.fromBinary(beefBinaryV2)
     console.log('BEEF V2 Object:', beefV2)
     console.log('BEEF V2 log:', beefV2.toLogString())
     console.log('BEEF V2 isValid:', beefV2.isValid())
@@ -37,7 +37,7 @@ describe.skip('postBeef service tests', () => {
     // Step 2: Modify version to V1 using beef.verion and Test
     console.log('Testing BEEF V1...')
     const beefBinaryV1tmp = [...beefBinaryV2]
-    const beefV1 = bsv.Beef.fromBinary(beefBinaryV1tmp)
+    const beefV1 = Beef.fromBinary(beefBinaryV1tmp)
 
     beefV1.version = BEEF_V1
     console.log('BEEF V1 Object:', beefV1)

--- a/src/services/__tests/postTxs.test.ts
+++ b/src/services/__tests/postTxs.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef, Utils } from '@bsv/sdk'
 import { Services } from "../../index.client"
 
 describe('postTxs service tests', () => {
@@ -11,8 +11,8 @@ describe('postTxs service tests', () => {
 
         const txid = '1e3a4e2a952414081ec8576480b00dc2c1eeb04655480a09f167f7d82ac6e74a'
         const rawTx = await services.getRawTx(txid)
-        const rawTxHex = bsv.Utils.toHex(rawTx.rawTx!)
-        const beef = new bsv.Beef()
+        const rawTxHex = Utils.toHex(rawTx.rawTx!)
+        const beef = new Beef()
         beef.mergeRawTx(rawTx.rawTx!)
         const r = await services.postTxs(beef, [txid])
         expect(r[0].status).toBe('success')

--- a/src/services/__tests/walletLive.test.ts
+++ b/src/services/__tests/walletLive.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from '@bsv/sdk'
+import { Beef, CreateActionArgs, InternalizeActionArgs, KeyDeriverApi, PrivateKey, Utils, WalletInterface } from '@bsv/sdk'
 import { Services, asString, StorageKnex, sdk, table, verifyOne, verifyId, ScriptTemplateSABPPP, randomBytesBase64 } from '../../index.all'
 import { _tu, TestWalletNoSetup } from '../../../test/utils/TestUtilsWalletStorage'
 
@@ -89,10 +89,10 @@ describe.skip('walletLive test', () => {
   test('5 pull out txid from BEEF', async () => {
     const beefHex =
       '010101015c574f48257202b9bff1b14baaa31cea24b9132555216900c277566d440250c50200beef01fee100190003020602f1fdbfa55c7227d2d9f93b7c2b83596a8e336ced483c1616dd98e8a32054dc6307010102009602f0b0959d085cbfda1a0958f65882b1a2829d66853582c0a530586dd00e930100002a7f27bd83b7d490f6641bbd3a8bdeff31490c14430597302ba579392be33f730201000100000001faba5977e9d7894778490ad3d3cf3ff0144da2920f6b31869dbcc026b693061b000000006a473044022050b2a300cad0e4b4c5ecaf93445937f21f6ec61d0c1726ac46bfb5bc2419af2102205d53e70fbdb0d1181a3cb1ef437ae27a73320367fdb78e8cadbfcbf82054e696412102480166f272ee9b639317c16ee60a2254ece67d0c7190fedbd26d57ac30f69d65ffffffff1da861000000000000c421029b09fdddfae493e309d3d97b919f6ab2902a789158f6f78489ad903b7a14baeaac2131546f446f44744b7265457a6248594b466a6d6f42756475466d53585855475a4735840423b7e26b5fd304a88f2ea28c9cf04d6c0a6c52a3174b69ea097039a355dbc6d95e702ac325c3f07518c9b4370796f90ad74e1c46304402206cd8228dd5102f7d8bd781e71dbf60df6559e90df9b79ed1c2b51d0316432f5502207a8713e899232190322dd4fdac6384f6b416ffa10b4196cdc7edbaf751b4a1156d7502000000000000001976a914ee8f77d351270123065a30a13e30394cbb4a6a2b88ace8030000000000001976a9147c8d0d51b07812872049e60e65a28d1041affc1f88ace8030000000000001976a914494c42ae91ebb8d4df662b0c2c98acfcbf14aff388ac93070000000000001976a9149619d3a2c3669335175d6fbd1d785719418cd69588acef030000000000001976a91435aabdafdc475012b7e2b7ab42e8f0fd9e8b665588ac59da0000000000001976a914c05b882ce290b3c19fbb0fca21e416f204d855a188acf3030000000000001976a9146ccff9f5e40844b784f1a68269afe30f5ec84c5d88accb340d00000000001976a914baf2186a8228a9581e0af744e28424343c6a464d88ace9030000000000001976a914a9c3b08f698df167c352f56aad483c907a0e64f488ac61140000000000001976a914f391b03543456ca68f3953b5ef4883f1299b4a2c88ac44c10500000000001976a914e6631bf6d96f93db48fb51daeace803ad805c09788ace9030000000000001976a9148cac2669fc696f5fb39aa59360a2cd20a6daffac88ac49b00400000000001976a9142c16b8a63604c66aa51f47f499024e327657ab5388acd7d50100000000001976a914ca5b56f03f796f55583c7cdd612c02f8d232669388ac42050000000000001976a914175a6812dbf2a550b1bf0d21594b96f9daf60d7988ac15040000000000001976a9147422a7237bb0fa77691047abf930e0274d193fe788ace9030000000000001976a9141a32c1c07dd4f9c632ce6b43dd28c8b27a37d81588ace8030000000000001976a914d9433de1883950578e9a29013aedb1e66d900bdc88ac39190000000000001976a9149fcdbc118b0114d2cc086a75eb14d880e3e25a9e88ac55390200000000001976a914cccf036ec7ae05690461c9d1be10193b6427055588ac1d010000000000001976a9148578396af7a6783824ff680315cc0a1375d9586e88acb3090000000000001976a9147c63cace8600f5400c8678cb2c843400c0c8ac2788acc55d0000000000001976a9148bf6991866b525f36dda54f7ca393c3a56cfff7188acc9100b00000000001976a914af41bf9bbf9d345f6b7cb37958d4cf43e88b17ef88acda040000000000001976a914ad818fcb671cc5b85dc22056d97a9b31aede4f3288ace8030000000000001976a91403ae9f7e41baee27ab7e66a323e73ee6801b5e1688ac59040000000000001976a9149f19356274a53ffdfb755bd81d40a97fe79b5e9b88ac10340000000000001976a914504dff507fccce4005f2d374cbdb6d5d493ceda288ac00000000000100000001f1fdbfa55c7227d2d9f93b7c2b83596a8e336ced483c1616dd98e8a32054dc63060000006b4830450221009bb61b5ec65cbcee0705cf757eba43e1716bfebf3ef976a09ffc926edee9ce6c022060606f5b5e59a6210067633a1263c23156d426feb1912cea480789beef62568741210208132e357b0d061848e779700eae5d69e5240a2503dd753a00e6cb3a8a920255ffffffff06e8030000000000001976a9149cedb88029c24f8bb9824628dfa0a023c1db5edc88acb40a0000000000001976a914da9b117c6880799eb3a0d0ccca252d7f11be240588ac35290000000000001976a914a8f814d3e2a2112bfe2f158f0596314a4379d45088ac54600000000000001976a91476f6f9a9ede3b7e496c921e6730be0af8d3fdfda88ac0e040000000000001976a91419a4615e24931e0e3b25e150fb362b56c5f4e89688ac253e0000000000001976a91435f0dcc5f8c47821a9d24d456b09995981cdb03f88ac00000000'
-    const beef = bsv.Beef.fromString(beefHex)
+    const beef = Beef.fromString(beefHex)
     const btx = beef.findTxid('5c574f48257202b9bff1b14baaa31cea24b9132555216900c277566d440250c5')
     console.log(`
-  tx: '${bsv.Utils.toHex(btx?.rawTx!)}'
+  tx: '${Utils.toHex(btx?.rawTx!)}'
 
   ${beef.toLogString()}
 
@@ -100,7 +100,7 @@ describe.skip('walletLive test', () => {
   })
 
   test('6a help setup my own wallet', async () => {
-    const privKey = bsv.PrivateKey.fromRandom()
+    const privKey = PrivateKey.fromRandom()
     const identityKey = privKey.toPublicKey().toString()
 
     const log = `
@@ -143,8 +143,8 @@ describe.skip('walletLive test', () => {
     }
     */
 
-    const args: bsv.InternalizeActionArgs = {
-      tx: bsv.Utils.toArray(r.atomicBEEF, 'hex'),
+    const args: InternalizeActionArgs = {
+      tx: Utils.toArray(r.atomicBEEF, 'hex'),
       outputs: [
         {
           outputIndex: r.vout,
@@ -210,7 +210,7 @@ async function confirmSpendableOutputs(storage: StorageKnex, services: Services)
   return { invalidSpendableOutputs }
 }
 
-export async function createWalletPaymentAction(args: { toIdentityKey: string; outputSatoshis: number; keyDeriver: bsv.KeyDeriverApi; wallet: bsv.WalletInterface; logResult?: boolean }): Promise<{
+export async function createWalletPaymentAction(args: { toIdentityKey: string; outputSatoshis: number; keyDeriver: KeyDeriverApi; wallet: WalletInterface; logResult?: boolean }): Promise<{
   senderIdentityKey: string
   vout: number
   txid: string
@@ -222,7 +222,7 @@ export async function createWalletPaymentAction(args: { toIdentityKey: string; o
 
   const t = new ScriptTemplateSABPPP({ derivationPrefix: randomBytesBase64(8), derivationSuffix: randomBytesBase64(8), keyDeriver })
 
-  const createArgs: bsv.CreateActionArgs = {
+  const createArgs: CreateActionArgs = {
     description: `pay ${args.toIdentityKey}`.slice(0, 50),
     outputs: [{ satoshis: outputSatoshis, lockingScript: t.lock(keyDeriver.rootKey.toString(), toIdentityKey).toHex(), outputDescription: `for ${args.toIdentityKey}`.slice(0, 50) }],
     options: {
@@ -240,7 +240,7 @@ export async function createWalletPaymentAction(args: { toIdentityKey: string; o
     txid: cr.txid!,
     derivationPrefix: t.params.derivationPrefix!,
     derivationSuffix: t.params.derivationSuffix!,
-    atomicBEEF: bsv.Utils.toHex(cr.tx!)
+    atomicBEEF: Utils.toHex(cr.tx!)
   }
 
   if (args.logResult) {

--- a/src/signer/WalletSigner.ts
+++ b/src/signer/WalletSigner.ts
@@ -1,22 +1,22 @@
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs, AbortActionResult, AcquireCertificateArgs, AcquireCertificateResult, Transaction as BsvTransaction, CreateActionArgs, CreateActionResult, DiscoverByAttributesArgs, DiscoverByIdentityKeyArgs, DiscoverCertificatesResult, InternalizeActionArgs, InternalizeActionResult, KeyDeriver, KeyDeriverApi, ListActionsArgs, ListActionsResult, ListCertificatesArgs, ListCertificatesResult, ListOutputsArgs, ListOutputsResult, ProtoWallet, ProveCertificateArgs, ProveCertificateResult, RelinquishCertificateArgs, RelinquishCertificateResult, RelinquishOutputArgs, RelinquishOutputResult, SignActionArgs, SignActionResult } from '@bsv/sdk';
 import { sdk } from "../index.client";
 import { WalletStorageManager } from "../storage/WalletStorageManager";
-import { createAction } from "./methods/createAction";
-import { signAction } from "./methods/signAction";
-import { internalizeAction } from "./methods/internalizeAction";
 import { acquireDirectCertificate } from "./methods/acquireDirectCertificate";
+import { createAction } from "./methods/createAction";
+import { internalizeAction } from "./methods/internalizeAction";
 import { proveCertificate } from "./methods/proveCertificate";
+import { signAction } from "./methods/signAction";
 
 export class WalletSigner implements sdk.WalletSigner {
     chain: sdk.Chain
-    keyDeriver: bsv.KeyDeriverApi
+    keyDeriver: KeyDeriverApi
     storage: WalletStorageManager
     _services?: sdk.WalletServices
     identityKey: string
 
     pendingSignActions: Record<string, PendingSignAction>
 
-    constructor(chain: sdk.Chain, keyDeriver: bsv.KeyDeriver, storage: WalletStorageManager) {
+    constructor(chain: sdk.Chain, keyDeriver: KeyDeriver, storage: WalletStorageManager) {
         if (storage._authId.identityKey != keyDeriver.identityKey) throw new sdk.WERR_INVALID_PARAMETER('storage', `authenticated as the same identityKey (${storage._authId.identityKey}) as the keyDeriver (${keyDeriver.identityKey}).`);
         this.chain = chain
         this.keyDeriver = keyDeriver
@@ -26,7 +26,7 @@ export class WalletSigner implements sdk.WalletSigner {
         this.pendingSignActions = {}
     }
 
-    getProtoWallet() : bsv.ProtoWallet { return new bsv.ProtoWallet(this.keyDeriver) }
+    getProtoWallet() : ProtoWallet { return new ProtoWallet(this.keyDeriver) }
 
     setServices(v: sdk.WalletServices) {
         this._services = v
@@ -61,70 +61,70 @@ export class WalletSigner implements sdk.WalletSigner {
         return { vargs, auth }
     }
 
-    async listActions(args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult> {
+    async listActions(args: ListActionsArgs): Promise<ListActionsResult> {
         this.validateAuthAndArgs(args, sdk.validateListActionsArgs)
         const r = await this.storage.listActions(args)
         return r
     }
-    async listOutputs(args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult> {
+    async listOutputs(args: ListOutputsArgs): Promise<ListOutputsResult> {
         this.validateAuthAndArgs(args, sdk.validateListOutputsArgs)
         const r = await this.storage.listOutputs(args)
         return r
     }
-    async listCertificates(args: bsv.ListCertificatesArgs): Promise<bsv.ListCertificatesResult> {
+    async listCertificates(args: ListCertificatesArgs): Promise<ListCertificatesResult> {
         const { vargs } = this.validateAuthAndArgs(args, sdk.validateListCertificatesArgs)
         const r = await this.storage.listCertificates(vargs)
         return r
     }
 
-    async abortAction(args: bsv.AbortActionArgs): Promise<bsv.AbortActionResult> {
+    async abortAction(args: AbortActionArgs): Promise<AbortActionResult> {
         const { auth } = this.validateAuthAndArgs(args, sdk.validateAbortActionArgs)
         const r = await this.storage.abortAction(args)
         return r
     }
-    async createAction(args: bsv.CreateActionArgs): Promise<bsv.CreateActionResult> {
+    async createAction(args: CreateActionArgs): Promise<CreateActionResult> {
         const { auth, vargs } = this.validateAuthAndArgs(args, sdk.validateCreateActionArgs)
         const r = await createAction(this, auth, vargs)
         return r
     }
 
-    async signAction(args: bsv.SignActionArgs): Promise<bsv.SignActionResult> {
+    async signAction(args: SignActionArgs): Promise<SignActionResult> {
         const { auth, vargs } = this.validateAuthAndArgs(args, sdk.validateSignActionArgs)
         const r = await signAction(this, auth, vargs)
         return r
     }
-    async internalizeAction(args: bsv.InternalizeActionArgs): Promise<bsv.InternalizeActionResult> {
+    async internalizeAction(args: InternalizeActionArgs): Promise<InternalizeActionResult> {
         const { auth, vargs } = this.validateAuthAndArgs(args, sdk.validateInternalizeActionArgs)
         const r = await internalizeAction(this, auth, args)
         return r
     }
-    async relinquishOutput(args: bsv.RelinquishOutputArgs): Promise<bsv.RelinquishOutputResult> {
+    async relinquishOutput(args: RelinquishOutputArgs): Promise<RelinquishOutputResult> {
         const { vargs } = this.validateAuthAndArgs(args, sdk.validateRelinquishOutputArgs)
         const r = await this.storage.relinquishOutput(args)
         return { relinquished: true }
     }
-    async relinquishCertificate(args: bsv.RelinquishCertificateArgs): Promise<bsv.RelinquishCertificateResult> {
+    async relinquishCertificate(args: RelinquishCertificateArgs): Promise<RelinquishCertificateResult> {
         this.validateAuthAndArgs(args, sdk.validateRelinquishCertificateArgs)
         const r = await this.storage.relinquishCertificate(args)
         return { relinquished: true }
     }
-    async acquireDirectCertificate(args: bsv.AcquireCertificateArgs): Promise<bsv.AcquireCertificateResult> {
+    async acquireDirectCertificate(args: AcquireCertificateArgs): Promise<AcquireCertificateResult> {
         const { auth, vargs } = this.validateAuthAndArgs(args, sdk.validateAcquireDirectCertificateArgs)
         vargs.subject = (await this.getProtoWallet().getPublicKey({ identityKey: true, privileged: args.privileged, privilegedReason: args.privilegedReason })).publicKey
         const r = await acquireDirectCertificate(this, auth, vargs)
         return r
     }
-    async proveCertificate(args: bsv.ProveCertificateArgs): Promise<bsv.ProveCertificateResult> {
+    async proveCertificate(args: ProveCertificateArgs): Promise<ProveCertificateResult> {
         const { auth, vargs } = this.validateAuthAndArgs(args, sdk.validateProveCertificateArgs)
         const r = await proveCertificate(this, auth, vargs)
         return r
     }
 
-    async discoverByIdentityKey(args: bsv.DiscoverByIdentityKeyArgs): Promise<bsv.DiscoverCertificatesResult> {
+    async discoverByIdentityKey(args: DiscoverByIdentityKeyArgs): Promise<DiscoverCertificatesResult> {
         this.validateAuthAndArgs(args, sdk.validateDiscoverByIdentityKeyArgs)
         throw new Error("Method not implemented.");
     }
-    async discoverByAttributes(args: bsv.DiscoverByAttributesArgs): Promise<bsv.DiscoverCertificatesResult> {
+    async discoverByAttributes(args: DiscoverByAttributesArgs): Promise<DiscoverCertificatesResult> {
         this.validateAuthAndArgs(args, sdk.validateDiscoverByAttributesArgs)
         throw new Error("Method not implemented.");
     }
@@ -143,7 +143,7 @@ export interface PendingSignAction {
     reference: string
     dcr: sdk.StorageCreateActionResult
     args: sdk.ValidCreateActionArgs
-    tx: bsv.Transaction
+    tx: BsvTransaction
     amount: number
     pdi: PendingStorageInput[]
 }

--- a/src/signer/methods/acquireDirectCertificate.ts
+++ b/src/signer/methods/acquireDirectCertificate.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AcquireCertificateResult } from '@bsv/sdk'
 import { sdk, table, WalletSigner } from '../../index.client'
 
 export async function acquireDirectCertificate(
@@ -6,7 +6,7 @@ export async function acquireDirectCertificate(
   auth: sdk.AuthId,
   vargs: sdk.ValidAcquireDirectCertificateArgs
 )
-: Promise<bsv.AcquireCertificateResult>
+: Promise<AcquireCertificateResult>
 {
   const now = new Date()
   const newCert: table.CertificateX = {
@@ -38,7 +38,7 @@ export async function acquireDirectCertificate(
 
   const count = await signer.storage.insertCertificate(newCert)
 
-  const r: bsv.AcquireCertificateResult = {
+  const r: AcquireCertificateResult = {
     type: vargs.type,
     subject: vargs.subject,
     serialNumber: vargs.serialNumber,

--- a/src/signer/methods/createAction.ts
+++ b/src/signer/methods/createAction.ts
@@ -1,11 +1,11 @@
-import * as bsv from '@bsv/sdk'
+import { CreateActionResult, SendWithResult, SignActionResult, SignActionSpend } from '@bsv/sdk'
 import { Script, Transaction, TransactionInput } from "@bsv/sdk"
 import { asBsvSdkScript, makeAtomicBeef, PendingSignAction, PendingStorageInput, ScriptTemplateSABPPP, sdk, verifyId, verifyTruthy, WalletSigner } from "../../index.client"
 
 export async function createAction(signer: WalletSigner, auth: sdk.AuthId, vargs: sdk.ValidCreateActionArgs)
-: Promise<bsv.CreateActionResult>
+: Promise<CreateActionResult>
 {
-  const r: bsv.CreateActionResult = {}
+  const r: CreateActionResult = {}
   
   let prior: PendingSignAction | undefined = undefined
 
@@ -45,14 +45,14 @@ async function createNewTx(signer: WalletSigner, args: sdk.ValidCreateActionArgs
 }
 
 function makeSignableTransactionResult(prior: PendingSignAction, signer: WalletSigner, args: sdk.ValidCreateActionArgs)
-: bsv.CreateActionResult
+: CreateActionResult
 {
   if (!prior.dcr.inputBeef)
     throw new sdk.WERR_INTERNAL('prior.dcr.inputBeef must be valid')
 
   const txid = prior.tx.id('hex')
 
-  const r: bsv.CreateActionResult = {
+  const r: CreateActionResult = {
     noSendChange: args.isNoSend ? prior.dcr.noSendChangeOutputVouts?.map(vout => `${txid}.${vout}`) : undefined,
     signableTransaction: {
       reference: prior.dcr.reference,
@@ -85,7 +85,7 @@ function makeChangeLock(
 
 export async function completeSignedTransaction(
   prior: PendingSignAction,
-  spends: Record<number, bsv.SignActionSpend>,
+  spends: Record<number, SignActionSpend>,
   signer: WalletSigner,
 )
 : Promise<Transaction>
@@ -108,7 +108,7 @@ export async function completeSignedTransaction(
   }
 
   const results = {
-    sdk: <bsv.SignActionResult>{}
+    sdk: <SignActionResult>{}
   }
 
   /////////////////////
@@ -155,7 +155,7 @@ function removeUnlockScripts(args: sdk.ValidCreateActionArgs) {
 }
 
 export async function processAction(prior: PendingSignAction | undefined, signer: WalletSigner, auth: sdk.AuthId, vargs: sdk.ValidProcessActionArgs)
-: Promise<bsv.SendWithResult[] | undefined>
+: Promise<SendWithResult[] | undefined>
 {
   const args: sdk.StorageProcessActionArgs = {
     isNewTx: vargs.isNewTx,

--- a/src/signer/methods/proveCertificate.ts
+++ b/src/signer/methods/proveCertificate.ts
@@ -1,4 +1,4 @@
-import * as bsv from "@bsv/sdk";
+import { CompletedProtoWallet, ProveCertificateResult } from "@bsv/sdk";
 import { sdk, WalletSigner } from '../../index.client'
 
 export async function proveCertificate(
@@ -6,7 +6,7 @@ export async function proveCertificate(
   auth: sdk.AuthId,
   vargs: sdk.ValidProveCertificateArgs
 )
-: Promise<bsv.ProveCertificateResult>
+: Promise<ProveCertificateResult>
 {
   const lcargs: sdk.ValidListCertificatesArgs = {
     partial: {
@@ -28,14 +28,14 @@ export async function proveCertificate(
   if (lcr.certificates.length != 1)
     throw new sdk.WERR_INVALID_PARAMETER('args', `a unique certificate match`)
   const storageCert = lcr.certificates[0]
-  const wallet = new bsv.CompletedProtoWallet(signer.keyDeriver!)
+  const wallet = new CompletedProtoWallet(signer.keyDeriver!)
   const co = await sdk.CertOps.fromCounterparty(wallet, {
     certificate: { ...storageCert },
     keyring: storageCert.keyring!,
     counterparty: storageCert.verifier || storageCert.subject
   })
   const e = await co.exportForCounterparty(vargs.verifier, vargs.fieldsToReveal)
-  const pr: bsv.ProveCertificateResult = {
+  const pr: ProveCertificateResult = {
     certificate: e.certificate,
     verifier: e.counterparty,
     keyringForVerifier: e.keyring

--- a/src/signer/methods/signAction.ts
+++ b/src/signer/methods/signAction.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import * as bsv from '@bsv/sdk'
+import { Beef, Transaction as BsvTransaction, SignActionResult, SignActionSpend } from '@bsv/sdk'
 import { asBsvSdkScript, ScriptTemplateSABPPP, sdk } from "../../index.client"
 import { PendingSignAction, WalletSigner } from "../WalletSigner"
 import { processAction } from './createAction'
 
 export async function signAction(signer: WalletSigner, auth: sdk.AuthId, vargs: sdk.ValidSignActionArgs)
-: Promise<bsv.SignActionResult>
+: Promise<SignActionResult>
 {
   const prior = signer.pendingSignActions[vargs.reference]
   if (!prior)
@@ -18,7 +18,7 @@ export async function signAction(signer: WalletSigner, auth: sdk.AuthId, vargs: 
 
   const sendWithResults = await processAction(prior, signer, auth, vargs)
 
-  const r: bsv.SignActionResult = {
+  const r: SignActionResult = {
     txid: prior.tx.id('hex'),
     tx: vargs.options.returnTXIDOnly ? undefined : makeAtomicBeef(prior.tx, prior.dcr.inputBeef),
     sendWithResults
@@ -27,19 +27,19 @@ export async function signAction(signer: WalletSigner, auth: sdk.AuthId, vargs: 
   return r
 }
 
-export function makeAtomicBeef(tx: bsv.Transaction, beef: number[] | bsv.Beef) : number[] {
+export function makeAtomicBeef(tx: BsvTransaction, beef: number[] | Beef) : number[] {
   if (Array.isArray(beef))
-    beef = bsv.Beef.fromBinary(beef)
+    beef = Beef.fromBinary(beef)
   beef.mergeTransaction(tx)
   return beef.toBinaryAtomic(tx.id('hex'))
 }
 
 export async function completeSignedTransaction(
   prior: PendingSignAction,
-  spends: Record<number, bsv.SignActionSpend>,
+  spends: Record<number, SignActionSpend>,
   ninja: WalletSigner,
 )
-: Promise<bsv.Transaction>
+: Promise<BsvTransaction>
 {
 
   /////////////////////
@@ -59,7 +59,7 @@ export async function completeSignedTransaction(
   }
 
   const results = {
-    sdk: <bsv.SignActionResult>{}
+    sdk: <SignActionResult>{}
   }
 
   /////////////////////

--- a/src/storage/StorageKnex.ts
+++ b/src/storage/StorageKnex.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { ListActionsArgs, ListActionsResult, ListOutputsArgs, ListOutputsResult } from '@bsv/sdk'
 import { sdk, verifyOne, verifyOneOrNone, verifyTruthy } from '../index.all'
 import { KnexMigrations, table } from './index.all'
 
@@ -147,12 +147,12 @@ export class StorageKnex extends StorageProvider implements sdk.WalletStoragePro
     return this.validateEntities(rs, undefined, ['isDeleted'])
   }
 
-  override async listActions(auth: sdk.AuthId, args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult> {
+  override async listActions(auth: sdk.AuthId, args: ListActionsArgs): Promise<ListActionsResult> {
     if (!auth.userId) throw new sdk.WERR_UNAUTHORIZED()
     const vargs = sdk.validateListActionsArgs(args)
     return await listActions(this, auth, vargs)
   }
-  override async listOutputs(auth: sdk.AuthId, args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult> {
+  override async listOutputs(auth: sdk.AuthId, args: ListOutputsArgs): Promise<ListOutputsResult> {
     if (!auth.userId) throw new sdk.WERR_UNAUTHORIZED()
     const vargs = sdk.validateListOutputsArgs(args)
     return await listOutputs(this, auth, vargs)

--- a/src/storage/StorageProvider.ts
+++ b/src/storage/StorageProvider.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Transaction as BsvTransaction, AbortActionResult, Beef, InternalizeActionArgs, InternalizeActionResult, ListActionsArgs, ListActionsResult, ListOutputsArgs, ListOutputsResult, PubKeyHex, ListCertificatesResult, TrustSelf, RelinquishCertificateArgs, RelinquishOutputArgs } from '@bsv/sdk'
 import { asArray, asString, entity, sdk, table, verifyId, verifyOne, verifyOneOrNone, verifyTruthy } from "../index.client";
 import { getBeefForTransaction } from './methods/getBeefForTransaction';
 import { GetReqsAndBeefDetail, GetReqsAndBeefResult, processAction } from './methods/processAction';
@@ -14,7 +14,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
     _services?: sdk.WalletServices
     feeModel: sdk.StorageFeeModel
     commissionSatoshis: number
-    commissionPubKeyHex?: bsv.PubKeyHex
+    commissionPubKeyHex?: PubKeyHex
     maxRecursionDepth?: number
 
     static defaultOptions() {
@@ -50,8 +50,8 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
     abstract getLabelsForTransactionId(transactionId?: number, trx?: sdk.TrxToken): Promise<table.TxLabel[]>
     abstract getTagsForOutputId(outputId: number, trx?: sdk.TrxToken): Promise<table.OutputTag[]>
 
-    abstract listActions(auth: sdk.AuthId, args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult>
-    abstract listOutputs(auth: sdk.AuthId, args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult>
+    abstract listActions(auth: sdk.AuthId, args: ListActionsArgs): Promise<ListActionsResult>
+    abstract listOutputs(auth: sdk.AuthId, args: ListOutputsArgs): Promise<ListOutputsResult>
 
     abstract countChangeInputs(userId: number, basketId: number, excludeSending: boolean): Promise<number>
 
@@ -69,7 +69,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return this._services
     }
 
-    async abortAction(auth: sdk.AuthId, args: Partial<table.Transaction>): Promise<bsv.AbortActionResult> {
+    async abortAction(auth: sdk.AuthId, args: Partial<table.Transaction>): Promise<AbortActionResult> {
         const r = await this.transaction(async trx => {
             const tx = verifyOneOrNone(await this.findTransactions({ partial: args, noRawTx: true, trx }))
             const unAbortableStatus: sdk.TransactionStatus[] = ['completed', 'failed', 'sending', 'unproven']
@@ -84,7 +84,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
                     await req.updateStorageDynamicProperties(this, trx)
                 }
             }
-            const r: bsv.AbortActionResult = {
+            const r: AbortActionResult = {
                 aborted: true
             }
             return r
@@ -92,7 +92,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return r
     }
 
-    async internalizeAction(auth: sdk.AuthId, args: bsv.InternalizeActionArgs): Promise<bsv.InternalizeActionResult> {
+    async internalizeAction(auth: sdk.AuthId, args: InternalizeActionArgs): Promise<InternalizeActionResult> {
         return await internalizeAction(this, auth, args)
     }
 
@@ -108,7 +108,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
     async getReqsAndBeefToShareWithWorld(txids: string[], knownTxids: string[], trx?: sdk.TrxToken)
         : Promise<GetReqsAndBeefResult> {
         const r: GetReqsAndBeefResult = {
-            beef: new bsv.Beef(),
+            beef: new Beef(),
             details: []
         }
 
@@ -160,12 +160,12 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return r
     }
 
-    async mergeReqToBeefToShareExternally(req: table.ProvenTxReq, mergeToBeef: bsv.Beef, knownTxids: string[], trx?: sdk.TrxToken): Promise<void> {
+    async mergeReqToBeefToShareExternally(req: table.ProvenTxReq, mergeToBeef: Beef, knownTxids: string[], trx?: sdk.TrxToken): Promise<void> {
         const { rawTx, inputBEEF: beef } = req;
         if (!rawTx || !beef) throw new sdk.WERR_INTERNAL(`req rawTx and beef must be valid.`);
         mergeToBeef.mergeRawTx(asArray(rawTx));
         mergeToBeef.mergeBeef(asArray(beef));
-        const tx = bsv.Transaction.fromBinary(asArray(rawTx));
+        const tx = BsvTransaction.fromBinary(asArray(rawTx));
         for (const input of tx.inputs) {
             if (!input.sourceTXID) throw new sdk.WERR_INTERNAL(`req all transaction inputs must have valid sourceTXID`);
             const txid = input.sourceTXID
@@ -303,7 +303,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return await attemptToPostReqsToNetwork(this, reqs, trx)
     }
 
-    async listCertificates(auth: sdk.AuthId, args: sdk.ValidListCertificatesArgs): Promise<bsv.ListCertificatesResult> {
+    async listCertificates(auth: sdk.AuthId, args: sdk.ValidListCertificatesArgs): Promise<ListCertificatesResult> {
         return await listCertificates(this, auth, args)
     }
 
@@ -312,16 +312,16 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return proven != undefined || rawTx != undefined
     }
 
-    async getValidBeefForKnownTxid(txid: string, mergeToBeef?: bsv.Beef, trustSelf?: bsv.TrustSelf, knownTxids?: string[], trx?: sdk.TrxToken): Promise<bsv.Beef> {
+    async getValidBeefForKnownTxid(txid: string, mergeToBeef?: Beef, trustSelf?: TrustSelf, knownTxids?: string[], trx?: sdk.TrxToken): Promise<Beef> {
         const beef = await this.getValidBeefForTxid(txid, mergeToBeef, trustSelf, knownTxids, trx)
         if (!beef)
             throw new sdk.WERR_INVALID_PARAMETER('txid', `${txid} is not known to storage.`)
         return beef
     }
 
-    async getValidBeefForTxid(txid: string, mergeToBeef?: bsv.Beef, trustSelf?: bsv.TrustSelf, knownTxids?: string[], trx?: sdk.TrxToken): Promise<bsv.Beef | undefined> {
+    async getValidBeefForTxid(txid: string, mergeToBeef?: Beef, trustSelf?: TrustSelf, knownTxids?: string[], trx?: sdk.TrxToken): Promise<Beef | undefined> {
 
-        const beef = mergeToBeef || new bsv.Beef()
+        const beef = mergeToBeef || new Beef()
 
         const r = await this.getProvenOrRawTx(txid, trx)
         if (r.proven) {
@@ -341,7 +341,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
             else {
                 beef.mergeRawTx(r.rawTx)
                 beef.mergeBeef(r.inputBEEF)
-                const tx = bsv.Transaction.fromBinary(r.rawTx)
+                const tx = BsvTransaction.fromBinary(r.rawTx)
                 for (const input of tx.inputs) {
                     const btx = beef.findTxid(input.sourceTXID!)
                     if (!btx) {
@@ -358,7 +358,7 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return undefined
     }
 
-    async getBeefForTransaction(txid: string, options: sdk.StorageGetBeefOptions): Promise<bsv.Beef> {
+    async getBeefForTransaction(txid: string, options: sdk.StorageGetBeefOptions): Promise<Beef> {
         return await getBeefForTransaction(this, txid, options)
     }
 
@@ -366,13 +366,13 @@ export abstract class StorageProvider extends StorageReaderWriter implements sdk
         return verifyOneOrNone(await this.findMonitorEvents({ partial: { id }, trx }))
     }
 
-    async relinquishCertificate(auth: sdk.AuthId, args: bsv.RelinquishCertificateArgs): Promise<number> {
+    async relinquishCertificate(auth: sdk.AuthId, args: RelinquishCertificateArgs): Promise<number> {
         const vargs = sdk.validateRelinquishCertificateArgs(args)
         const cert = verifyOne(await this.findCertificates({ partial: { certifier: vargs.certifier, serialNumber: vargs.serialNumber, type: vargs.type } }))
         return await this.updateCertificate(cert.certificateId, { isDeleted: true })
     }
 
-    async relinquishOutput(auth: sdk.AuthId, args: bsv.RelinquishOutputArgs): Promise<number> {
+    async relinquishOutput(auth: sdk.AuthId, args: RelinquishOutputArgs): Promise<number> {
         const vargs = sdk.validateRelinquishOutputArgs(args)
         const { txid, vout } = sdk.parseWalletOutpoint(vargs.output)
         const output = verifyOne(await this.findOutputs({ partial: { txid, vout } }))
@@ -523,7 +523,7 @@ export interface StorageProviderOptions extends StorageReaderWriterOptions {
      * The actual locking script for each commission will use a public key derived
      * from this key by information stored in the commissions table.
      */
-    commissionPubKeyHex?: bsv.PubKeyHex
+    commissionPubKeyHex?: PubKeyHex
 }
 
 export function validateStorageFeeModel (v?: sdk.StorageFeeModel): sdk.StorageFeeModel {

--- a/src/storage/WalletStorageManager.ts
+++ b/src/storage/WalletStorageManager.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs, AbortActionResult, InternalizeActionArgs, InternalizeActionResult, ListActionsArgs, ListActionsResult, ListCertificatesResult, ListOutputsArgs, ListOutputsResult, RelinquishCertificateArgs, RelinquishOutputArgs } from '@bsv/sdk'
 import { entity, sdk, StorageProvider, StorageSyncReader, table, wait } from "../index.client";
 
 /**
@@ -229,7 +229,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
         })
     }
 
-    async abortAction(args: bsv.AbortActionArgs): Promise<bsv.AbortActionResult> {
+    async abortAction(args: AbortActionArgs): Promise<AbortActionResult> {
         const vargs = sdk.validateAbortActionArgs(args)
         const auth = await this.getAuth()
         return await this.runAsWriter(async (writer) => {
@@ -246,7 +246,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
 
         })
     }
-    async internalizeAction(args: bsv.InternalizeActionArgs): Promise<bsv.InternalizeActionResult> {
+    async internalizeAction(args: InternalizeActionArgs): Promise<InternalizeActionResult> {
         const auth = await this.getAuth()
         return await this.runAsWriter(async (writer) => {
 
@@ -255,7 +255,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
         })
     }
 
-    async relinquishCertificate(args: bsv.RelinquishCertificateArgs): Promise<number> {
+    async relinquishCertificate(args: RelinquishCertificateArgs): Promise<number> {
         const vargs = sdk.validateRelinquishCertificateArgs(args)
         const auth = await this.getAuth()
         return await this.runAsWriter(async (writer) => {
@@ -264,7 +264,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
 
         })
     }
-    async relinquishOutput(args: bsv.RelinquishOutputArgs): Promise<number> {
+    async relinquishOutput(args: RelinquishOutputArgs): Promise<number> {
         const vargs = sdk.validateRelinquishOutputArgs(args)
         const auth = await this.getAuth()
         return await this.runAsWriter(async (writer) => {
@@ -291,7 +291,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
         })
     }
 
-    async listActions(args: bsv.ListActionsArgs): Promise<bsv.ListActionsResult> {
+    async listActions(args: ListActionsArgs): Promise<ListActionsResult> {
         const vargs = sdk.validateListActionsArgs(args)
         const auth = await this.getAuth()
         return await this.runAsReader(async (reader) => {
@@ -300,7 +300,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
 
         })
     }
-    async listCertificates(args: sdk.ValidListCertificatesArgs): Promise<bsv.ListCertificatesResult> {
+    async listCertificates(args: sdk.ValidListCertificatesArgs): Promise<ListCertificatesResult> {
         const auth = await this.getAuth()
         return await this.runAsReader(async (reader) => {
 
@@ -308,7 +308,7 @@ export class WalletStorageManager implements sdk.WalletStorage {
 
         })
     }
-    async listOutputs(args: bsv.ListOutputsArgs): Promise<bsv.ListOutputsResult> {
+    async listOutputs(args: ListOutputsArgs): Promise<ListOutputsResult> {
         const vargs = sdk.validateListOutputsArgs(args)
         const auth = await this.getAuth()
         return await this.runAsReader(async (reader) => {

--- a/src/storage/methods/__test/GenerateChange/generateChangeSdk.test.ts
+++ b/src/storage/methods/__test/GenerateChange/generateChangeSdk.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import * as bsv from '@bsv/sdk'
+import { Transaction as BsvTransaction, Script } from '@bsv/sdk'
 import { randomValsUsed1 } from "./randomValsUsed1";
 import { sdk } from "../../../../index.client";
 import { generateChangeSdk, GenerateChangeSdkChangeInput, generateChangeSdkMakeStorage, GenerateChangeSdkParams, GenerateChangeSdkResult } from '../../generateChange';
@@ -354,31 +354,31 @@ async function expectToThrowWERR<R>(expectedClass: new (...args: any[]) => any, 
     throw new Error(`${expectedClass.name} was not thrown`)
 }
 
-function makeTransaction(params: GenerateChangeSdkParams, results: GenerateChangeSdkResult) : bsv.Transaction {
-    const tx = new bsv.Transaction()
+function makeTransaction(params: GenerateChangeSdkParams, results: GenerateChangeSdkResult) : BsvTransaction {
+    const tx = new BsvTransaction()
     for (const i of params.fixedInputs) {
         tx.inputs.push({
-            unlockingScript: bsv.Script.fromBinary(Array(i.unlockingScriptLength).fill(0)),
+            unlockingScript: Script.fromBinary(Array(i.unlockingScriptLength).fill(0)),
             sourceOutputIndex: 0,
             sourceTXID: '00'.repeat(32)
         })
     }
     for (const i of results.allocatedChangeInputs) {
         tx.inputs.push({
-            unlockingScript: bsv.Script.fromBinary(Array(params.changeUnlockingScriptLength).fill(0)),
+            unlockingScript: Script.fromBinary(Array(params.changeUnlockingScriptLength).fill(0)),
             sourceOutputIndex: 0,
             sourceTXID: '00'.repeat(32)
         })
     }
     for (const o of params.fixedOutputs) {
         tx.outputs.push({
-            lockingScript: bsv.Script.fromBinary(Array(o.lockingScriptLength).fill(0)),
+            lockingScript: Script.fromBinary(Array(o.lockingScriptLength).fill(0)),
             satoshis: o.satoshis
         })
     }
     for (const o of results.changeOutputs) {
         tx.outputs.push({
-            lockingScript: bsv.Script.fromBinary(Array(o.lockingScriptLength).fill(0)),
+            lockingScript: Script.fromBinary(Array(o.lockingScriptLength).fill(0)),
             satoshis: o.satoshis
         })
     }

--- a/src/storage/methods/attemptToPostReqsToNetwork.ts
+++ b/src/storage/methods/attemptToPostReqsToNetwork.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef } from '@bsv/sdk'
 import { StorageProvider } from "../StorageProvider"
 import { entity, sdk } from '../../index.client'
 
@@ -12,7 +12,7 @@ export async function attemptToPostReqsToNetwork(storage: StorageProvider, reqs:
 
     const r: PostReqsToNetworkResult = {
         status: 'success',
-        beef: new bsv.Beef(),
+        beef: new Beef(),
         details: [],
         log: ''
     }
@@ -157,7 +157,7 @@ export interface PostReqsToNetworkDetails {
 
 export interface PostReqsToNetworkResult {
     status: "success" | "error"
-    beef: bsv.Beef
+    beef: Beef
     details: PostReqsToNetworkDetails[]
     pbr?: sdk.PostBeefResult
     log: string

--- a/src/storage/methods/createAction.ts
+++ b/src/storage/methods/createAction.ts
@@ -1,8 +1,8 @@
-import * as bsv from '@bsv/sdk'
+import { Beef, BigNumber, Curve, OriginatorDomainNameStringUnder250Bytes, P2PKH, PrivateKey, PubKeyHex, PublicKey, Script } from '@bsv/sdk'
 import { asArray, asString, entity, randomBytesBase64, sdk, sha256Hash, stampLog, stampLogFormat, StorageProvider, table, validateStorageFeeModel, verifyId, verifyNumber, verifyOne, verifyOneOrNone, verifyTruthy } from "../../index.client";
 import { generateChangeSdk, GenerateChangeSdkChangeInput, GenerateChangeSdkParams } from './generateChange';
 
-export async function createAction(storage: StorageProvider, auth: sdk.AuthId, vargs: sdk.ValidCreateActionArgs, originator?: bsv.OriginatorDomainNameStringUnder250Bytes)
+export async function createAction(storage: StorageProvider, auth: sdk.AuthId, vargs: sdk.ValidCreateActionArgs, originator?: OriginatorDomainNameStringUnder250Bytes)
 : Promise<sdk.StorageCreateActionResult> {
   //stampLog(vargs, `start dojo createTransactionSdk`) 
 
@@ -82,7 +82,7 @@ interface CreateTransactionSdkContext {
 
 interface XValidCreateActionInput extends sdk.ValidCreateActionInput {
   vin: number
-  lockingScript: bsv.Script
+  lockingScript: Script
   satoshis: number
   output?: table.Output
 }
@@ -338,7 +338,7 @@ async function createNewOutputs(dojo: StorageProvider, userId: number, vargs: sd
   return {outputs, changeVouts}
 }
 
-async function createNewTxRecord(dojo: StorageProvider, userId: number, vargs: sdk.ValidCreateActionArgs, storageBeef: bsv.Beef)
+async function createNewTxRecord(dojo: StorageProvider, userId: number, vargs: sdk.ValidCreateActionArgs, storageBeef: Beef)
 : Promise<table.Transaction>
 {
   const now = new Date()
@@ -371,12 +371,12 @@ async function createNewTxRecord(dojo: StorageProvider, userId: number, vargs: s
 /**
  * Convert vargs.outputs:
  *
- * lockingScript: bsv.HexString
- * satoshis: bsv.SatoshiValue
- * outputDescription: bsv.DescriptionString5to50Bytes
- * basket?: bsv.BasketStringUnder300Bytes
+ * lockingScript: HexString
+ * satoshis: SatoshiValue
+ * outputDescription: DescriptionString5to50Bytes
+ * basket?: BasketStringUnder300Bytes
  * customInstructions?: string
- * tags: bsv.BasketStringUnderBytes[]
+ * tags: BasketStringUnderBytes[]
  *
  * to XValidCreateActionOutput (which aims for sdk.StorageCreateTransactionSdkOutput)
  * 
@@ -449,17 +449,17 @@ function validateRequiredOutputs(dojo: StorageProvider, userId: number, vargs: s
  * @returns {xinputs} extended validated required inputs.
  */
 async function validateRequiredInputs(dojo: StorageProvider, userId: number, vargs: sdk.ValidCreateActionArgs)
-: Promise<{storageBeef: bsv.Beef, beef: bsv.Beef, xinputs: XValidCreateActionInput[]}>
+: Promise<{storageBeef: Beef, beef: Beef, xinputs: XValidCreateActionInput[]}>
 {
   //stampLog(vargs, `start dojo verifyInputBeef`)
 
-  const beef = new bsv.Beef()
+  const beef = new Beef()
 
   if (vargs.inputs.length === 0) return { storageBeef: beef, beef, xinputs: [] }
 
   if (vargs.inputBEEF) beef.mergeBeef(vargs.inputBEEF)
 
-  const xinputs: XValidCreateActionInput[] = vargs.inputs.map((input, vin) => ({...input, vin, satoshis: -1, lockingScript: new bsv.Script() }))
+  const xinputs: XValidCreateActionInput[] = vargs.inputs.map((input, vin) => ({...input, vin, satoshis: -1, lockingScript: new Script() }))
 
   const trustSelf = vargs.options.trustSelf === 'known'
 
@@ -514,7 +514,7 @@ async function validateRequiredInputs(dojo: StorageProvider, userId: number, var
         throw new sdk.WERR_INVALID_PARAMETER(`${txid}.${vout}`, 'spendable output unless noSend is true');
       // input is spending an existing user output which has an lockingScript
       input.satoshis = verifyNumber(output.satoshis)
-      input.lockingScript = bsv.Script.fromBinary(asArray(output.lockingScript!))
+      input.lockingScript = Script.fromBinary(asArray(output.lockingScript!))
     } else {
       let btx = beef.findTxid(txid)!
       if (btx.isTxidOnly) {
@@ -674,7 +674,7 @@ async function fundNewTransactionSdk(dojo: StorageProvider, userId: number, varg
  * in the `beef` to txidOnly.
  * @returns undefined if `vargs.options.returnTXIDOnly` or trimmed `Beef`
  */
-function trimInputBeef(beef: bsv.Beef, vargs: sdk.ValidCreateActionArgs): number[] | undefined {
+function trimInputBeef(beef: Beef, vargs: sdk.ValidCreateActionArgs): number[] | undefined {
   if (vargs.options.returnTXIDOnly) return undefined
   const knownTxids: Record<string, boolean> = {}
   for (const txid of vargs.options.knownTxids) knownTxids[txid] = true
@@ -684,7 +684,7 @@ function trimInputBeef(beef: bsv.Beef, vargs: sdk.ValidCreateActionArgs): number
 
 async function mergeAllocatedChangeBeefs(dojo: StorageProvider, userId: number, vargs: sdk.ValidCreateActionArgs,
   allocatedChange: table.Output[],
-  beef: bsv.Beef
+  beef: Beef
 )
 : Promise<number[] | undefined>
 {
@@ -706,35 +706,35 @@ async function mergeAllocatedChangeBeefs(dojo: StorageProvider, userId: number, 
   return trimInputBeef(beef, vargs)
 }
 
-function keyOffsetToHashedSecret (pub: bsv.PublicKey, keyOffset?: string): { hashedSecret: bsv.BigNumber, keyOffset: string } {
-  let offset: bsv.PrivateKey
+function keyOffsetToHashedSecret (pub: PublicKey, keyOffset?: string): { hashedSecret: BigNumber, keyOffset: string } {
+  let offset: PrivateKey
   if (keyOffset !== undefined && typeof keyOffset === 'string') {
     if (keyOffset.length === 64)
-      offset = bsv.PrivateKey.fromString(keyOffset, 'hex')
+      offset = PrivateKey.fromString(keyOffset, 'hex')
     else
-      offset = bsv.PrivateKey.fromWif(keyOffset)
+      offset = PrivateKey.fromWif(keyOffset)
   } else {
-    offset = bsv.PrivateKey.fromRandom()
+    offset = PrivateKey.fromRandom()
     keyOffset = offset.toWif()
   }
 
   const sharedSecret = pub.mul(offset).encode(true, undefined) as number[]
   const hashedSecret = sha256Hash(sharedSecret)
 
-  return { hashedSecret: new bsv.BigNumber(hashedSecret), keyOffset }
+  return { hashedSecret: new BigNumber(hashedSecret), keyOffset }
 }
 
 
 export function offsetPubKey (pubKey: string, keyOffset?: string): { offsetPubKey: string, keyOffset: string } {
-  const pub = bsv.PublicKey.fromString(pubKey)
+  const pub = PublicKey.fromString(pubKey)
 
   const r = keyOffsetToHashedSecret(pub, keyOffset)
 
   // The hashed secret is multiplied by the generator point.
-  const point = new bsv.Curve().g.mul(r.hashedSecret)
+  const point = new Curve().g.mul(r.hashedSecret)
 
   // The resulting point is added to the recipient public key.
-  const offsetPubKey = new bsv.PublicKey(pub.add(point))
+  const offsetPubKey = new PublicKey(pub.add(point))
 
   return { offsetPubKey: offsetPubKey.toString(), keyOffset: r.keyOffset }
 }
@@ -742,16 +742,16 @@ export function offsetPubKey (pubKey: string, keyOffset?: string): { offsetPubKe
 export function lockScriptWithKeyOffsetFromPubKey (pubKey: string, keyOffset?: string): { script: string, keyOffset: string } {
   const r = offsetPubKey(pubKey, keyOffset)
 
-  const offsetPub = bsv.PublicKey.fromString(r.offsetPubKey)
+  const offsetPub = PublicKey.fromString(r.offsetPubKey)
 
   const hash = offsetPub.toHash() as number[]
 
-  const script = new bsv.P2PKH().lock(hash).toHex()
+  const script = new P2PKH().lock(hash).toHex()
 
   return { script, keyOffset: r.keyOffset }
 }
 
-export function createStorageServiceChargeScript(pubKeyHex: bsv.PubKeyHex)
+export function createStorageServiceChargeScript(pubKeyHex: PubKeyHex)
 : { script: string, keyOffset: string }
 {
   return lockScriptWithKeyOffsetFromPubKey(pubKeyHex)

--- a/src/storage/methods/getBeefForTransaction.ts
+++ b/src/storage/methods/getBeefForTransaction.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef } from '@bsv/sdk'
 import { asBsvSdkTx, entity, sdk, StorageProvider, verifyTruthy } from '../../index.client'
 
 /**
@@ -19,13 +19,13 @@ import { asBsvSdkTx, entity, sdk, StorageProvider, verifyTruthy } from '../../in
  * @param txid the transaction hash for which an envelope is requested.
  * @param options
  */
-export async function getBeefForTransaction(storage: StorageProvider, txid: string, options: sdk.StorageGetBeefOptions) : Promise<bsv.Beef>
+export async function getBeefForTransaction(storage: StorageProvider, txid: string, options: sdk.StorageGetBeefOptions) : Promise<Beef>
 {
     const beef =
         // deserialize mergeToBeef if it is an array
-        Array.isArray(options.mergeToBeef) ? bsv.Beef.fromBinary(options.mergeToBeef)
+        Array.isArray(options.mergeToBeef) ? Beef.fromBinary(options.mergeToBeef)
         // otherwise if undefined create a new Beef
-        : (options.mergeToBeef || new bsv.Beef())
+        : (options.mergeToBeef || new Beef())
 
     await mergeBeefForTransactionRecurse(beef, storage, txid, options, 0)
 
@@ -45,12 +45,12 @@ async function getProvenOrRawTxFromServices(dojo: StorageProvider, txid: string,
 }
 
 async function mergeBeefForTransactionRecurse(
-    beef: bsv.Beef,
+    beef: Beef,
     dojo: StorageProvider,
     txid: string,
     options: sdk.StorageGetBeefOptions,
     recursionDepth: number
-): Promise<bsv.Beef> {
+): Promise<Beef> {
     const maxDepth = dojo.maxRecursionDepth;
     if (maxDepth && maxDepth <= recursionDepth) throw new sdk.WERR_INVALID_OPERATION(`Maximum BEEF depth exceeded. Limit is ${dojo.maxRecursionDepth}`);
 

--- a/src/storage/methods/listActions.ts
+++ b/src/storage/methods/listActions.ts
@@ -1,4 +1,4 @@
-import * as bsv from "@bsv/sdk"
+import { Transaction as BsvTransaction, ActionStatus, ListActionsResult, WalletAction, WalletActionOutput, WalletActionInput } from "@bsv/sdk"
 import { table } from "../index.client"
 import { asString, sdk, verifyOne } from "../../index.client"
 import { StorageKnex } from "../StorageKnex"
@@ -8,14 +8,14 @@ export async function listActions(
     auth: sdk.AuthId,
     vargs: sdk.ValidListActionsArgs
 )
-: Promise<bsv.ListActionsResult>
+: Promise<ListActionsResult>
 {
     const limit = vargs.limit
     const offset = vargs.offset
 
     const k = storage.toDb(undefined)
 
-    const r: bsv.ListActionsResult = {
+    const r: ListActionsResult = {
         totalActions: 0,
         actions: []
     }
@@ -94,10 +94,10 @@ export async function listActions(
     }
 
     for (const tx of txs) {
-        const wtx: bsv.WalletAction = {
+        const wtx: WalletAction = {
             txid: tx.txid || '',
             satoshis: tx.satoshis || 0,
-            status: <bsv.ActionStatus>tx.status!,
+            status: <ActionStatus>tx.status!,
             isOutgoing: !!tx.isOutgoing,
             description: tx.description || '',
             version: tx.version || 0,
@@ -121,7 +121,7 @@ export async function listActions(
                 action.outputs = []
                 for (const o of outputs) {
                     await storage.extendOutput(o, true, true)
-                    const wo: bsv.WalletActionOutput = {
+                    const wo: WalletActionOutput = {
                         satoshis: o.satoshis || 0,
                         spendable: !!o.spendable,
                         tags: o.tags?.map(t => t.tag) || [],
@@ -139,9 +139,9 @@ export async function listActions(
                 action.inputs = []
                 if (inputs.length > 0) {
                     const rawTx = await storage.getRawTxOfKnownValidTransaction(tx.txid)
-                    let bsvTx: bsv.Transaction | undefined = undefined
+                    let bsvTx: BsvTransaction | undefined = undefined
                     if (rawTx) {
-                        bsvTx = bsv.Transaction.fromBinary(rawTx)
+                        bsvTx = BsvTransaction.fromBinary(rawTx)
                     }
                     for (const o of inputs) {
                         await storage.extendOutput(o, true, true)
@@ -149,7 +149,7 @@ export async function listActions(
                             v.sourceTXID === o.txid
                             && v.sourceOutputIndex === o.vout
                         )
-                        const wo: bsv.WalletActionInput = {
+                        const wo: WalletActionInput = {
                             sourceOutpoint: `${o.txid}.${o.vout}`,
                             sourceSatoshis: o.satoshis || 0,
                             inputDescription: o.outputDescription || '',

--- a/src/storage/methods/listCertificates.ts
+++ b/src/storage/methods/listCertificates.ts
@@ -1,4 +1,4 @@
-import * as bsv from "@bsv/sdk"
+import { ListCertificatesResult, OriginatorDomainNameStringUnder250Bytes } from "@bsv/sdk"
 import { StorageProvider, table } from "../index.client"
 import { sdk } from "../../index.client"
 
@@ -6,9 +6,9 @@ export async function listCertificates(
     storage: StorageProvider,
     auth: sdk.AuthId,
     vargs: sdk.ValidListCertificatesArgs,
-    originator?: bsv.OriginatorDomainNameStringUnder250Bytes,
+    originator?: OriginatorDomainNameStringUnder250Bytes,
 )
-: Promise<bsv.ListCertificatesResult>
+: Promise<ListCertificatesResult>
 {
     const paged: sdk.Paged = { limit: vargs.limit, offset: vargs.offset }
 
@@ -35,7 +35,7 @@ export async function listCertificates(
                 masterKeyring: Object.fromEntries(fields.map(f => ([f.fieldName, f.masterKey])))
             }
         }))
-        const r: bsv.ListCertificatesResult = {
+        const r: ListCertificatesResult = {
             totalCertificates: 0,
             certificates: certsWithFields.map(cwf => ({
                 type: cwf.type,

--- a/src/storage/methods/listOutputs.ts
+++ b/src/storage/methods/listOutputs.ts
@@ -1,4 +1,4 @@
-import * as bsv from "@bsv/sdk"
+import { Beef, ListOutputsResult, OriginatorDomainNameStringUnder250Bytes, WalletOutput } from "@bsv/sdk"
 import { table } from "../index.client"
 import { asString, sdk, verifyId, verifyOne } from "../../index.client"
 import { StorageKnex } from "../StorageKnex"
@@ -7,9 +7,9 @@ export async function listOutputs(
     dsk: StorageKnex,
     auth: sdk.AuthId,
     vargs: sdk.ValidListOutputsArgs,
-    originator?: bsv.OriginatorDomainNameStringUnder250Bytes,
+    originator?: OriginatorDomainNameStringUnder250Bytes,
 )
-: Promise<bsv.ListOutputsResult>
+: Promise<ListOutputsResult>
 {
     const trx: sdk.TrxToken | undefined = undefined
     const userId = verifyId(auth.userId)
@@ -18,7 +18,7 @@ export async function listOutputs(
 
     const k = dsk.toDb(trx)
 
-    const r: bsv.ListOutputsResult = {
+    const r: ListOutputsResult = {
         totalOutputs: 0,
         outputs: []
     }
@@ -166,10 +166,10 @@ export async function listOutputs(
 
     const labelsByTxid: Record<string, string[]> = {}
 
-    const beef = new bsv.Beef()
+    const beef = new Beef()
 
     for (const o of outputs) {
-        const wo: bsv.WalletOutput = {
+        const wo: WalletOutput = {
             satoshis: Number(o.satoshis),
             spendable: !!o.spendable,
             outpoint: `${o.txid}.${o.vout}`

--- a/src/storage/methods/processAction.ts
+++ b/src/storage/methods/processAction.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import * as bsv from '@bsv/sdk'
+import { Beef, Transaction as BsvTransaction, SendWithResult, SendWithResultStatus } from '@bsv/sdk'
 import { asArray, asString, entity, parseTxScriptOffsets, randomBytesBase64, sdk, sha256Hash, stampLog, stampLogFormat, StorageProvider, table, TxScriptOffsets, validateStorageFeeModel, verifyId, verifyNumber, verifyOne, verifyOneOrNone, verifyTruthy } from "../../index.client";
 
 export async function processAction(
@@ -55,7 +55,7 @@ export async function processAction(
  * @param isDelayed 
  */
 async function shareReqsWithWorld(storage: StorageProvider, userId: number, txids: string[], isDelayed: boolean)
-: Promise<bsv.SendWithResult[]>
+: Promise<SendWithResult[]>
 {
     if (txids.length < 1) return []
 
@@ -119,10 +119,10 @@ async function shareReqsWithWorld(storage: StorageProvider, userId: number, txid
 
     return rs
 
-    function createSendWithResults(): bsv.SendWithResult[] {
-        const rs: bsv.SendWithResult[] = []
+    function createSendWithResults(): SendWithResult[] {
+        const rs: SendWithResult[] = []
         for (const ar of ars) {
-            let status: bsv.SendWithResultStatus = 'failed';
+            let status: SendWithResultStatus = 'failed';
             if (ar.getReq.status === 'alreadySent')
                 status = 'unproven';
             else if (ar.getReq.status === 'readyToSend' && (isDelayed || ar.postBeef?.status === 'success'))
@@ -151,14 +151,14 @@ interface ValidCommitNewTxToStorageArgs {
 
     // validated dependent args
 
-    tx: bsv.Transaction
+    tx: BsvTransaction
     txScriptOffsets: TxScriptOffsets
     transactionId: number
     transaction: table.Transaction
     inputOutputs: table.Output[]
     outputOutputs: table.Output[]
     commission: table.Commission | undefined
-    beef: bsv.Beef
+    beef: Beef
 
     req: entity.ProvenTxReq
     outputUpdates: { id: number, update: Partial<table.Output> }[]
@@ -171,9 +171,9 @@ async function validateCommitNewTxToStorageArgs(storage: StorageProvider, userId
 {
     if (!params.reference || !params.txid || !params.rawTx)
         throw new sdk.WERR_INVALID_OPERATION('One or more expected params are undefined.')
-    let tx: bsv.Transaction
+    let tx: BsvTransaction
     try {
-        tx = bsv.Transaction.fromBinary(params.rawTx)
+        tx = BsvTransaction.fromBinary(params.rawTx)
     } catch (e: unknown) {
         throw new sdk.WERR_INVALID_OPERATION('Parsing serialized transaction failed.')
     }
@@ -188,7 +188,7 @@ async function validateCommitNewTxToStorageArgs(storage: StorageProvider, userId
     const transaction = verifyOne(await storage.findTransactions({ partial: { userId, reference: params.reference } }))
     if (!transaction.isOutgoing) throw new sdk.WERR_INVALID_OPERATION('isOutgoing is not true')
     if (!transaction.inputBEEF) throw new sdk.WERR_INVALID_OPERATION()
-    const beef = bsv.Beef.fromBinary(asArray(transaction.inputBEEF))
+    const beef = Beef.fromBinary(asArray(transaction.inputBEEF))
     // TODO: Could check beef validates transaction inputs...
     // Transaction must have unsigned or unprocessed status
     if (transaction.status !== 'unsigned' && transaction.status !== 'unprocessed')
@@ -347,7 +347,7 @@ export interface GetReqsAndBeefDetail {
 }
 
 export interface GetReqsAndBeefResult {
-    beef: bsv.Beef,
+    beef: Beef,
     details: GetReqsAndBeefDetail[]
 }
 

--- a/src/storage/methods/purgeData.ts
+++ b/src/storage/methods/purgeData.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef } from '@bsv/sdk'
 import { Knex } from "knex"
 import { table } from "../index.client"
 import { sdk } from "../../index.client"
@@ -108,7 +108,7 @@ export async function purgeData(storage: StorageKnex, params: sdk.PurgeParams, t
         const age = params.purgeSpentAge || defaultAge
         const before = toSqlWhereDate(new Date(Date.now() - age))
 
-        const beef = new bsv.Beef()
+        const beef = new Beef()
         const utxos = await storage.findOutputs({ partial: { spendable: true }, txStatus: ['sending', 'unproven', 'completed', 'nosend']})
         for (const utxo of utxos) {
             // Figure out all the txids required to prove the validity of this utxo and merge proofs into beef.

--- a/src/storage/remoting/StorageClient.ts
+++ b/src/storage/remoting/StorageClient.ts
@@ -5,7 +5,7 @@
  * by sending JSON-RPC calls to a configured remote WalletStorageServer.
  */
 
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs, AbortActionResult, InternalizeActionArgs, InternalizeActionResult, ListActionsArgs, ListActionsResult, ListCertificatesResult, ListOutputsArgs, ListOutputsResult, RelinquishCertificateArgs, RelinquishOutputArgs, WalletInterface } from '@bsv/sdk'
 import { sdk, table } from "../../index.client";
 import { AuthFetch } from '@bsv/sdk';
 
@@ -20,7 +20,7 @@ export class StorageClient implements sdk.WalletStorageProvider {
     // Track ephemeral (in-memory) "settings" if you wish to align with isAvailable() checks
     public settings?: table.Settings
 
-    constructor(wallet: bsv.WalletInterface, endpointUrl: string) {
+    constructor(wallet: WalletInterface, endpointUrl: string) {
         this.authClient = new AuthFetch(wallet)
         this.endpointUrl = endpointUrl
     }
@@ -117,9 +117,9 @@ export class StorageClient implements sdk.WalletStorageProvider {
 
     async internalizeAction(
         auth: sdk.AuthId,
-        args: bsv.InternalizeActionArgs,
-    ): Promise<bsv.InternalizeActionResult> {
-        return this.rpcCall<bsv.InternalizeActionResult>("internalizeAction", [auth, args])
+        args: InternalizeActionArgs,
+    ): Promise<InternalizeActionResult> {
+        return this.rpcCall<InternalizeActionResult>("internalizeAction", [auth, args])
     }
 
     async createAction(
@@ -138,9 +138,9 @@ export class StorageClient implements sdk.WalletStorageProvider {
 
     async abortAction(
         auth: sdk.AuthId,
-        args: bsv.AbortActionArgs,
-    ): Promise<bsv.AbortActionResult> {
-        return this.rpcCall<bsv.AbortActionResult>("abortAction", [auth, args])
+        args: AbortActionArgs,
+    ): Promise<AbortActionResult> {
+        return this.rpcCall<AbortActionResult>("abortAction", [auth, args])
     }
 
     async findOrInsertUser(
@@ -175,23 +175,23 @@ export class StorageClient implements sdk.WalletStorageProvider {
 
     async listActions(
         auth: sdk.AuthId,
-        args: bsv.ListActionsArgs,
-    ): Promise<bsv.ListActionsResult> {
-        return this.rpcCall<bsv.ListActionsResult>("listActions", [auth, args])
+        args: ListActionsArgs,
+    ): Promise<ListActionsResult> {
+        return this.rpcCall<ListActionsResult>("listActions", [auth, args])
     }
 
     async listOutputs(
         auth: sdk.AuthId,
-        args: bsv.ListOutputsArgs,
-    ): Promise<bsv.ListOutputsResult> {
-        return this.rpcCall<bsv.ListOutputsResult>("listOutputs", [auth, args])
+        args: ListOutputsArgs,
+    ): Promise<ListOutputsResult> {
+        return this.rpcCall<ListOutputsResult>("listOutputs", [auth, args])
     }
 
     async listCertificates(
         auth: sdk.AuthId,
         args: sdk.ValidListCertificatesArgs,
-    ): Promise<bsv.ListCertificatesResult> {
-        return this.rpcCall<bsv.ListCertificatesResult>("listCertificates", [auth, args])
+    ): Promise<ListCertificatesResult> {
+        return this.rpcCall<ListCertificatesResult>("listCertificates", [auth, args])
     }
 
     async findCertificatesAuth(
@@ -223,14 +223,14 @@ export class StorageClient implements sdk.WalletStorageProvider {
 
     async relinquishCertificate(
         auth: sdk.AuthId,
-        args: bsv.RelinquishCertificateArgs
+        args: RelinquishCertificateArgs
     ): Promise<number> {
         return this.rpcCall<number>("relinquishCertificate", [auth, args])
     }
 
     async relinquishOutput(
         auth: sdk.AuthId,
-        args: bsv.RelinquishOutputArgs
+        args: RelinquishOutputArgs
     ): Promise<number> {
         return this.rpcCall<number>("relinquishOutput", [auth, args])
     }

--- a/src/storage/remoting/StorageServer.ts
+++ b/src/storage/remoting/StorageServer.ts
@@ -5,7 +5,7 @@
  * and exposes it via a JSON-RPC POST endpoint using Express.
  */
 
-import * as bsv from '@bsv/sdk'
+import { WalletInterface } from '@bsv/sdk'
 import express, { Request, Response } from 'express'
 import { AuthMiddlewareOptions, createAuthMiddleware } from '@bsv/auth-express-middleware'
 import { createPaymentMiddleware } from '@bsv/payment-express-middleware'
@@ -57,7 +57,7 @@ export class StorageServer {
     })
 
     const options: AuthMiddlewareOptions = {
-      wallet: this.wallet as bsv.WalletInterface
+      wallet: this.wallet as WalletInterface
     }
     this.app.use(createAuthMiddleware(options))
     if (this.monetize) {

--- a/src/storage/schema/entities/Transaction.ts
+++ b/src/storage/schema/entities/Transaction.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from "@bsv/sdk"
-import { arraysEqual, entity, optionalArraysEqual, sdk, table, verifyId, verifyOneOrNone } from "../../../index.client";
+import { Transaction as BsvTransaction, TransactionInput } from "@bsv/sdk"
+import { entity, optionalArraysEqual, sdk, table, verifyId, verifyOneOrNone } from "../../../index.client";
 import { EntityBase } from ".";
 
 export class Transaction extends EntityBase<table.Transaction> {
@@ -9,17 +9,17 @@ export class Transaction extends EntityBase<table.Transaction> {
      * @returns @bsv/sdk Transaction object from parsed rawTx.
      * If rawTx is undefined, returns undefined.
      */
-    getBsvTx() : bsv.Transaction | undefined {
+    getBsvTx() : BsvTransaction | undefined {
         if (!this.rawTx)
             return undefined
-        return bsv.Transaction.fromBinary(this.rawTx)
+        return BsvTransaction.fromBinary(this.rawTx)
     }
 
     /**
      * @returns array of @bsv/sdk TransactionInput objects from parsed rawTx.
      * If rawTx is undefined, an empty array is returned.
      */
-    getBsvTxIns() : bsv.TransactionInput[] {
+    getBsvTxIns() : TransactionInput[] {
         const tx = this.getBsvTx()
         if (!tx) return []
         return tx.inputs

--- a/src/storage/schema/tables/Certificate.ts
+++ b/src/storage/schema/tables/Certificate.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String, HexString, OutpointString, PubKeyHex } from '@bsv/sdk'
 import { sdk, table } from "../../../index.client"
 
 export interface Certificate extends sdk.EntityTimeStamp {
@@ -6,13 +6,13 @@ export interface Certificate extends sdk.EntityTimeStamp {
    updated_at: Date
    certificateId: number
    userId: number
-   type: bsv.Base64String
-   serialNumber: bsv.Base64String
-   certifier: bsv.PubKeyHex
-   subject: bsv.PubKeyHex
-   verifier?: bsv.PubKeyHex
-   revocationOutpoint: bsv.OutpointString
-   signature: bsv.HexString
+   type: Base64String
+   serialNumber: Base64String
+   certifier: PubKeyHex
+   subject: PubKeyHex
+   verifier?: PubKeyHex
+   revocationOutpoint: OutpointString
+   signature: HexString
    isDeleted: boolean
 }
 

--- a/src/storage/schema/tables/CertificateField.ts
+++ b/src/storage/schema/tables/CertificateField.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String } from '@bsv/sdk'
 import { sdk } from "../../../index.client"
 
 export interface CertificateField extends sdk.EntityTimeStamp {
@@ -8,7 +8,7 @@ export interface CertificateField extends sdk.EntityTimeStamp {
    certificateId: number
    fieldName: string
    fieldValue: string
-   masterKey: bsv.Base64String
+   masterKey: Base64String
 }
 
 

--- a/src/storage/schema/tables/Output.ts
+++ b/src/storage/schema/tables/Output.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String, DescriptionString5to50Bytes, PubKeyHex } from '@bsv/sdk'
 import { OutputBasket, OutputTag } from "."
 import { sdk } from "../../../index.client"
 
@@ -11,16 +11,16 @@ export interface Output extends sdk.EntityTimeStamp {
    basketId?: number
    spendable: boolean
    change: boolean
-   outputDescription: bsv.DescriptionString5to50Bytes
+   outputDescription: DescriptionString5to50Bytes
    vout: number
    satoshis: number
    providedBy: sdk.StorageProvidedBy
    purpose: string
    type: string
    txid?: string
-   senderIdentityKey?: bsv.PubKeyHex
-   derivationPrefix?: bsv.Base64String
-   derivationSuffix?: bsv.Base64String
+   senderIdentityKey?: PubKeyHex
+   derivationPrefix?: Base64String
+   derivationSuffix?: Base64String
    customInstructions?: string
    spentBy?: number
    sequenceNumber?: number

--- a/src/storage/schema/tables/Transaction.ts
+++ b/src/storage/schema/tables/Transaction.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String } from '@bsv/sdk'
 import { sdk } from "../../../index.client"
 
 export interface Transaction extends sdk.EntityTimeStamp {
@@ -11,7 +11,7 @@ export interface Transaction extends sdk.EntityTimeStamp {
    /**
      * max length of 64, hex encoded
      */
-   reference: bsv.Base64String
+   reference: Base64String
    /**
      * true if transaction originated in this wallet, change returns to it.
      * false for a transaction created externally and handed in to this wallet.

--- a/src/storage/sync/StorageMySQLDojoReader.ts
+++ b/src/storage/sync/StorageMySQLDojoReader.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Utils } from '@bsv/sdk'
 import {
     asArray,
     asString,
@@ -629,6 +629,6 @@ function convertSyncStatus(status: DojoSyncStatus) : sdk.SyncStatus {
 
 function forceToBase64(s?: string | null) : string {
     if (!s) return randomBytesBase64(12);
-    if (isHexString(s)) return bsv.Utils.toBase64(asArray(s.trim()));
+    if (isHexString(s)) return Utils.toBase64(asArray(s.trim()));
     return s.trim()
 }

--- a/src/utility/ScriptTemplateSABPPP.ts
+++ b/src/utility/ScriptTemplateSABPPP.ts
@@ -1,15 +1,14 @@
-import * as bsv from '@bsv/sdk'
+import { HexString, KeyDeriver, KeyDeriverApi, WalletProtocol } from '@bsv/sdk'
 import { asBsvSdkPrivateKey, verifyTruthy } from "./index.client";
 import { LockingScript, P2PKH, PrivateKey, Script, ScriptTemplate, Transaction, UnlockingScript } from "@bsv/sdk";
-import { sdk } from "../index.client";
 
 export interface ScriptTemplateParamsSABPPP {
    derivationPrefix?: string
    derivationSuffix?: string
-   keyDeriver: bsv.KeyDeriverApi
+   keyDeriver: KeyDeriverApi
 }
 
-export const brc29ProtocolID: bsv.WalletProtocol = [2, '3241645161d8']
+export const brc29ProtocolID: WalletProtocol = [2, '3241645161d8']
 
 export class ScriptTemplateSABPPP implements ScriptTemplate {
     p2pkh: P2PKH
@@ -23,11 +22,11 @@ export class ScriptTemplateSABPPP implements ScriptTemplate {
 
     getKeyID() { return `${this.params.derivationPrefix} ${this.params.derivationSuffix}` }
 
-    getKeyDeriver(privKey: PrivateKey | bsv.HexString) : bsv.KeyDeriverApi {
+    getKeyDeriver(privKey: PrivateKey | HexString) : KeyDeriverApi {
         if (typeof privKey === 'string')
             privKey = PrivateKey.fromHex(privKey)
         if (!this.params.keyDeriver || this.params.keyDeriver.rootKey.toHex() !== privKey.toHex())
-            return new bsv.KeyDeriver(privKey)
+            return new KeyDeriver(privKey)
         return this.params.keyDeriver
     }
 

--- a/src/utility/tscProofToMerklePath.ts
+++ b/src/utility/tscProofToMerklePath.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { MerklePath } from '@bsv/sdk'
 
 export interface TscMerkleProofApi {
   height: number
@@ -6,7 +6,7 @@ export interface TscMerkleProofApi {
   nodes: string[]
 }
 
-export function convertProofToMerklePath(txid: string, proof: TscMerkleProofApi): bsv.MerklePath {
+export function convertProofToMerklePath(txid: string, proof: TscMerkleProofApi): MerklePath {
     const blockHeight = proof.height
     const treeHeight = proof.nodes.length
     type Leaf = {
@@ -42,6 +42,6 @@ export function convertProofToMerklePath(txid: string, proof: TscMerkleProofApi)
         }
         index = index >> 1
     }
-    return new bsv.MerklePath(blockHeight, path)
+    return new MerklePath(blockHeight, path)
 }
 

--- a/src/utility/utilityHelpers.noBuffer.ts
+++ b/src/utility/utilityHelpers.noBuffer.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Utils } from '@bsv/sdk'
 
 /**
  * Coerce a value to a hex encoded string if currently a hex encoded string or number[]
@@ -8,11 +8,11 @@ import * as bsv from '@bsv/sdk'
  */
 export function asString(val: string | number[]): string {
   if (typeof val === 'string') return val
-  return bsv.Utils.toHex(val)
+  return Utils.toHex(val)
 }
 
 export function asArray(val: string | number[]): number[] {
   if (Array.isArray(val)) return val
-  let a: number[] = bsv.Utils.toArray(val, 'hex')
+  let a: number[] = Utils.toArray(val, 'hex')
   return a
 }

--- a/src/utility/utilityHelpers.ts
+++ b/src/utility/utilityHelpers.ts
@@ -1,13 +1,13 @@
-import * as bsv from '@bsv/sdk'
+import { HexString, PubKeyHex, WalletInterface, WalletNetwork } from '@bsv/sdk'
 import { Beef, Hash, PrivateKey, PublicKey, Random, Script, Transaction, Utils } from "@bsv/sdk";
 import { sdk } from "../index.client";
 import { Chain } from "../sdk/types";
 
-export async function getIdentityKey(wallet: bsv.WalletInterface): Promise<bsv.PubKeyHex> {
+export async function getIdentityKey(wallet: WalletInterface): Promise<PubKeyHex> {
   return (await wallet.getPublicKey({ identityKey: true })).publicKey
 }
 
-export function toWalletNetwork(chain: Chain): bsv.WalletNetwork {
+export function toWalletNetwork(chain: Chain): WalletNetwork {
     return chain === 'main' ? 'mainnet' : 'testnet';
 }
 
@@ -23,7 +23,7 @@ export function makeAtomicBeef(tx: Transaction, beef: number[] | Beef) : number[
  * If tx is already a Transaction, just return it.
  * @publicbody
  */
-export function asBsvSdkTx(tx: bsv.HexString | number[] | Transaction): Transaction {
+export function asBsvSdkTx(tx: HexString | number[] | Transaction): Transaction {
   if (Array.isArray(tx)) {
     tx = Transaction.fromBinary(tx)
   } else if (typeof tx === 'string') {
@@ -37,7 +37,7 @@ export function asBsvSdkTx(tx: bsv.HexString | number[] | Transaction): Transact
  * If script is already a Script, just return it.
  * @publicbody
  */
-export function asBsvSdkScript(script: bsv.HexString | number[] | Script): Script {
+export function asBsvSdkScript(script: HexString | number[] | Script): Script {
   if (Array.isArray(script)) {
     script = Script.fromBinary(script)
   } else if (typeof script === 'string') {

--- a/test/Wallet/StorageClient/storageClient.test.ts
+++ b/test/Wallet/StorageClient/storageClient.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from '@bsv/sdk'
 import { sdk, StorageClient } from '../../../src/index.all'
 import { _tu, expectToThrowWERR, TestWalletNoSetup, TestWalletOnly } from '../../utils/TestUtilsWalletStorage'
 

--- a/test/Wallet/action/internalizeAction.a.test.ts
+++ b/test/Wallet/action/internalizeAction.a.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Beef, InternalizeOutput } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../../src/index.all'
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 import { getBeefForTransaction } from '../../../src/storage/methods/getBeefForTransaction'
@@ -82,14 +82,14 @@ describe.skip('internalizeAction tests', () => {
         //console.log('Atomic Transaction:', atomicTx)
 
         // {
-        //   const abeef = bsv.Beef.fromBinary(atomicTx)
+        //   const abeef = Beef.fromBinary(atomicTx)
         //   expect(abeef.atomicTxid).toBe('2795b293c698b2244147aaba745db887a632d21990c474df46d842ec3e52f122')
         // }
 
         // This needs to be a real output (the locking script and derivation bits / key need to work with each other)
         // But it is still a valid test to see what the reaction is to this nonsense :-)
         // Prepare output for internalization
-        const output: bsv.InternalizeOutput = {
+        const output: InternalizeOutput = {
           outputIndex: 2,
           protocol: 'wallet payment',
           paymentRemittance: {
@@ -172,14 +172,14 @@ describe.skip('internalizeAction tests', () => {
         //console.log('Atomic Transaction:', atomicTx)
 
         {
-          const abeef = bsv.Beef.fromBinary(atomicTx)
+          const abeef = Beef.fromBinary(atomicTx)
           expect(abeef.atomicTxid).toBe('a3b2f0935c7b5bb7a841a09e535c13be86f4df0e7a91cebdc33812bfcc0eb9d7')
         }
 
         // This needs to be a real output (the locking script and derivation bits / key need to work with each other)
         // But it is still a valid test to see what the reaction is to this nonsense :-)
         // Prepare output for internalization
-        const output: bsv.InternalizeOutput = {
+        const output: InternalizeOutput = {
           outputIndex: 0,
           protocol: 'basket insertion',
           // export interface BasketInsertion {
@@ -242,7 +242,7 @@ describe.skip('internalizeAction tests', () => {
         //console.log('Atomic Transaction:', atomicTx)
 
         // Prepare output for internalization
-        const output: bsv.InternalizeOutput = {
+        const output: InternalizeOutput = {
           outputIndex: 2,
           protocol: 'basket insertion',
           paymentRemittance: {
@@ -281,7 +281,7 @@ describe.skip('internalizeAction tests', () => {
   //     // const outputSatoshis = 42
   //     // let noSendChange: string[] | undefined
 
-  //     // const createArgs: bsv.CreateActionArgs = {
+  //     // const createArgs: CreateActionArgs = {
   //     //   description: `${kp.address} of ${root}`,
   //     //   outputs: [{ satoshis: outputSatoshis, lockingScript: _tu.getLockP2PKH(kp.address).toHex(), outputDescription: 'pay fred' }],
   //     //   options: {
@@ -303,14 +303,14 @@ describe.skip('internalizeAction tests', () => {
   //     // const st = cr.signableTransaction!
   //     // expect(st.reference).toBeTruthy()
   //     // // const tx = Transaction.fromAtomicBEEF(st.tx) // Transaction doesn't support V2 Beef yet.
-  //     // const atomicBeef = bsv.Beef.fromBinary(st.tx)
+  //     // const atomicBeef = Beef.fromBinary(st.tx)
 
-  //     const output: bsv.InternalizeOutput = {
+  //     const output: InternalizeOutput = {
   //       outputIndex: 0,
   //       protocol: 'wallet payment',
   //       paymentRemittance: {
-  //         derivationPrefix: bsv.Utils.toBase64([1, 2, 3]),
-  //         derivationSuffix: bsv.Utils.toBase64([4, 5, 6]),
+  //         derivationPrefix: Utils.toBase64([1, 2, 3]),
+  //         derivationSuffix: Utils.toBase64([4, 5, 6]),
   //         senderIdentityKey: '02ce39558560fe2219636460b1ce1d8bb5760097656bf2bf21f7d1db422223c4ee'
   //       }
   //     }
@@ -321,7 +321,7 @@ describe.skip('internalizeAction tests', () => {
   //     //     /** list of txids to be included as txidOnly if referenced. Validity is known to caller. */
   //     //     knownTxids?: string[]
   //     //     /** optional. If defined, raw transactions and merkle paths required by txid are merged to this instance and returned. Otherwise a new Beef is constructed and returned. */
-  //     //     mergeToBeef?: bsv.Beef | number[]
+  //     //     mergeToBeef?: Beef | number[]
   //     //     /** optional. Default is false. `dojo.storage` is used for raw transaction and merkle proof lookup */
   //     //     ignoreStorage?: boolean
   //     //     /** optional. Default is false. `dojo.getServices` is used for raw transaction and merkle proof lookup */
@@ -361,8 +361,8 @@ describe.skip('internalizeAction tests', () => {
   //         outputIndex: 0,
   //         protocol: 'wallet payment' as 'wallet payment',
   //         paymentRemittance: {
-  //           derivationPrefix: bsv.Utils.toBase64([1, 2, 3]),
-  //           derivationSuffix: bsv.Utils.toBase64([4, 5, 6]),
+  //           derivationPrefix: Utils.toBase64([1, 2, 3]),
+  //           derivationSuffix: Utils.toBase64([4, 5, 6]),
   //           senderIdentityKey: '02' + '1'.repeat(64)
   //         }
   //       }

--- a/test/Wallet/certificate/acquireCertificate.test.ts
+++ b/test/Wallet/certificate/acquireCertificate.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AcquireCertificateArgs, CompletedProtoWallet, ProveCertificateArgs } from '@bsv/sdk'
 import { _tu, expectToThrowWERR } from "../../utils/TestUtilsWalletStorage"
 import { sdk, Wallet } from '../../../src/index.all'
 
@@ -16,7 +16,7 @@ describe('acquireCertificate tests', () => {
     test('1 invalid params', async () => {
         const { wallet, storage } = await _tu.createLegacyWalletSQLiteCopy('acquireCertificate1')
         
-        const invalidArgs: bsv.AcquireCertificateArgs[] = [
+        const invalidArgs: AcquireCertificateArgs[] = [
             {
                 type: "",
                 certifier: "",
@@ -41,7 +41,7 @@ describe('acquireCertificate tests', () => {
         const { cert, certifier } = _tu.makeSampleCert(subject)
 
         // Act as the certifier: create a wallet for them...
-        const certifierWallet = new bsv.CompletedProtoWallet(certifier)
+        const certifierWallet = new CompletedProtoWallet(certifier)
         // load the plaintext certificate into a CertOps object
         const co = new sdk.CertOps(certifierWallet, cert)
         // encrypt and sign the certificate
@@ -50,7 +50,7 @@ describe('acquireCertificate tests', () => {
         const { certificate: c, keyring: kr } = co.exportForSubject()
 
         // args object to create a new certificate via 'direct' protocol.
-        const args: bsv.AcquireCertificateArgs = {
+        const args: AcquireCertificateArgs = {
             serialNumber: c.serialNumber,
             signature: c.signature,
             privileged: false,
@@ -81,7 +81,7 @@ describe('acquireCertificate tests', () => {
         expect(lc.fields['name']).not.toBe('Alice')
 
         // Use proveCertificate to obtain a decryption keyring:
-        const pkrArgs: bsv.ProveCertificateArgs = {
+        const pkrArgs: ProveCertificateArgs = {
             certificate: { serialNumber: lc.serialNumber },
             fieldsToReveal: ['name'],
             verifier: subject

--- a/test/Wallet/certificate/listCertificates.test.ts
+++ b/test/Wallet/certificate/listCertificates.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { OriginatorDomainNameStringUnder250Bytes } from '@bsv/sdk'
 import { listCertificates } from '../../../src/storage/methods/listCertificates'
 import { StorageProvider } from '../../../src/storage/StorageProvider'
 import { sdk, table } from '../../../src/index.all'
@@ -12,7 +12,7 @@ describe('listCertificates', () => {
 
   // This is a valid, minimal set of arguments for listCertificates
   let vargs: sdk.ValidListCertificatesArgs
-  let originator: bsv.OriginatorDomainNameStringUnder250Bytes | undefined
+  let originator: OriginatorDomainNameStringUnder250Bytes | undefined
 
   // Helper so we can easily mock the transaction call
   const mockTransaction = async <T>(

--- a/test/Wallet/sync/Wallet.syncbob1.test.ts
+++ b/test/Wallet/sync/Wallet.syncbob1.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { CreateActionArgs, CreateActionResult, InternalizeActionArgs } from '@bsv/sdk'
 import { sdk, StorageKnex, StorageSyncReader, wait, Wallet, WalletStorageManager } from '../../../src/index.all'
 import { _tu, TestSetup1Wallet, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 
@@ -97,12 +97,12 @@ describe.skip('Wallet sync tests', () => {
       fred.storage.addWalletStorageProvider(backup)
       const promises: Promise<number>[] = []
       const result: { i: number; r: any }[] = []
-      const crs1: bsv.CreateActionResult[] = []
+      const crs1: CreateActionResult[] = []
       const maxI = 6
 
       // Create 1st set of outputs for writer internaliseAction
       for (let i = 0; i < maxI; i++) {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [{ satoshis: 1, lockingScript: _tu.getLockP2PKH(fredsAddress).toHex(), outputDescription: 'pay fred' }],
           options: {
@@ -140,13 +140,13 @@ describe.skip('Wallet sync tests', () => {
       storage.addWalletStorageProvider(backup)
       const promises: Promise<number>[] = []
       const result: { i: number; r: any }[] = []
-      const crs1: bsv.CreateActionResult[] = []
-      const crs2: bsv.CreateActionResult[] = []
+      const crs1: CreateActionResult[] = []
+      const crs2: CreateActionResult[] = []
       const maxI = 7
 
       // Create 1st set of outputs for writer internaliseAction
       for (let i = 0; i < maxI; i++) {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [{ satoshis: 1, lockingScript: _tu.getLockP2PKH(fredsAddress).toHex(), outputDescription: 'pay fred' }],
           options: {
@@ -166,9 +166,9 @@ describe.skip('Wallet sync tests', () => {
       expect(result).toBeTruthy()
     }
   })
-  async function makeWriter2(fred: TestWalletNoSetup, cr: bsv.CreateActionResult, i: number, result: { i: number; r: any }[]): Promise<number> {
+  async function makeWriter2(fred: TestWalletNoSetup, cr: CreateActionResult, i: number, result: { i: number; r: any }[]): Promise<number> {
     log(`called ${i}`)
-    const internalizeArgs: bsv.InternalizeActionArgs = {
+    const internalizeArgs: InternalizeActionArgs = {
       tx: cr.tx!,
       outputs: [
         {

--- a/test/monitor/Monitor.test.ts
+++ b/test/monitor/Monitor.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { MerklePath } from '@bsv/sdk'
 import { asArray, entity, sdk, verifyOne, verifyTruthy, wait } from "../../src/index.client"
 import { TaskCheckForProofs } from "../../src/monitor/tasks/TaskCheckForProofs"
 import { TaskClock } from "../../src/monitor/tasks/TaskClock"
@@ -231,27 +231,27 @@ describe('Monitor tests', () => {
     const mockGetMerklePathResults: sdk.GetMerklePathResult[] = [
         {
             name: "WoCTsc",
-            merklePath: new bsv.MerklePath( 1652142, [ [{ offset: 2, hash: "74c55a15a08ea491e02c41a6934c4177666c0dbda2781d0cf9743d3ad68a4623" }, { offset: 3, hash: "c099c52277426abb863dc902d0389b008ddf2301d6b40ac718746ac16ca59136", txid: true }], [{ offset: 0, hash: "2574544a253c91e69c7d5b4478af95d39420ad2c8e44c78b280f1bd5e7a11849" }], [{ offset: 1, hash: "8903289601da1910820c3471d41ae9187a7d46d6e39e636840b176519bdc5d00" }]]),
+            merklePath: new MerklePath( 1652142, [ [{ offset: 2, hash: "74c55a15a08ea491e02c41a6934c4177666c0dbda2781d0cf9743d3ad68a4623" }, { offset: 3, hash: "c099c52277426abb863dc902d0389b008ddf2301d6b40ac718746ac16ca59136", txid: true }], [{ offset: 0, hash: "2574544a253c91e69c7d5b4478af95d39420ad2c8e44c78b280f1bd5e7a11849" }], [{ offset: 1, hash: "8903289601da1910820c3471d41ae9187a7d46d6e39e636840b176519bdc5d00" }]]),
             header: { version: 536870912, previousHash: "0000000039f1c7dc943d50883e531022825bf5c15a40db2cedde7d203ca3d644", merkleRoot: "68bde58600fbd2c716871356cc2ad34b43ac67ac8d7a879dd966429d5a6935b2", time: 1734530373, bits: 474103450, nonce: 3894752803, height: 1652142, hash: "000000000d9419a409f83f16e2c162b4e44266986d6b9ee02d1b97d9556d9a3a" },
         },
         {
             name: "WoCTsc",
-            merklePath: new bsv.MerklePath(1652142, [[{ offset: 4, hash: "6935ce33b9e3b9ee60360ce0606aa0a0970b4840203f457b5559212676dc33ab", txid: true }, { offset: 5, duplicate: true }], [{ offset: 3, hash: "65b5a77f61ca87af5766546e4a22129da89f3378322ef29aac6cdc94c1f637f3" }], [{ offset: 0, hash: "0aeaa5c76cba5495f922ae0b52805c0d12c2ffa54d2829d250c958d67c7c5073" }]]),
+            merklePath: new MerklePath(1652142, [[{ offset: 4, hash: "6935ce33b9e3b9ee60360ce0606aa0a0970b4840203f457b5559212676dc33ab", txid: true }, { offset: 5, duplicate: true }], [{ offset: 3, hash: "65b5a77f61ca87af5766546e4a22129da89f3378322ef29aac6cdc94c1f637f3" }], [{ offset: 0, hash: "0aeaa5c76cba5495f922ae0b52805c0d12c2ffa54d2829d250c958d67c7c5073" }]]),
             header: { version: 536870912, previousHash: "0000000039f1c7dc943d50883e531022825bf5c15a40db2cedde7d203ca3d644", merkleRoot: "68bde58600fbd2c716871356cc2ad34b43ac67ac8d7a879dd966429d5a6935b2", time: 1734530373, bits: 474103450, nonce: 3894752803, height: 1652142, hash: "000000000d9419a409f83f16e2c162b4e44266986d6b9ee02d1b97d9556d9a3a" },
         },
         {
             name: "WoCTsc",
-            merklePath: new bsv.MerklePath(1652145, [[{ offset: 0, hash: "c160acfce1c29c648614b722f1c490473fd7aea0c60d21be95ae981eb0c9c4f0" }, { offset: 1, hash: "67ca2475886b3fc2edd76a2eb8c32bd0bc308176c7dff463e0507942aeebcbec", txid: true }], [{ offset: 1, hash: "c0eb049e4d3872d63bd3402dd4d6bc8022a170155493a994e1da692f08b2f2d0" }]]),
+            merklePath: new MerklePath(1652145, [[{ offset: 0, hash: "c160acfce1c29c648614b722f1c490473fd7aea0c60d21be95ae981eb0c9c4f0" }, { offset: 1, hash: "67ca2475886b3fc2edd76a2eb8c32bd0bc308176c7dff463e0507942aeebcbec", txid: true }], [{ offset: 1, hash: "c0eb049e4d3872d63bd3402dd4d6bc8022a170155493a994e1da692f08b2f2d0" }]]),
             header: { version: 536870912, previousHash: "000000001888ff57f4848f181f9f69cab27f2388d7c2edd99b8c004ae482cca7", merkleRoot: "f990936bc3267ba4911acc490107ed1841eedbd2c5017e1074891285df30f255", time: 1734532172, bits: 474081547, nonce: 740519774, height: 1652145, hash: "0000000003ea4ecae9254b992f292137fde1de66cc809d1a81cfd60cab4ba160" }
         },
         {
             name: "WoCTsc",
-            merklePath: new bsv.MerklePath(1652145, [[{ offset: 2, hash: "3fa94b62a3b10d8c18bada527a9b68c4e70db67140719df16c44fb0328782532", txid: true }, { offset: 3, duplicate: true }], [{ offset: 0, hash: "5eec838112f0eabc45e68c8ec14f76e74b0ea636180d91ccf034f5f3c5114edf" }]]),
+            merklePath: new MerklePath(1652145, [[{ offset: 2, hash: "3fa94b62a3b10d8c18bada527a9b68c4e70db67140719df16c44fb0328782532", txid: true }, { offset: 3, duplicate: true }], [{ offset: 0, hash: "5eec838112f0eabc45e68c8ec14f76e74b0ea636180d91ccf034f5f3c5114edf" }]]),
             header: { version: 536870912, previousHash: "000000001888ff57f4848f181f9f69cab27f2388d7c2edd99b8c004ae482cca7", merkleRoot: "f990936bc3267ba4911acc490107ed1841eedbd2c5017e1074891285df30f255", time: 1734532172, bits: 474081547, nonce: 740519774, height: 1652145, hash: "0000000003ea4ecae9254b992f292137fde1de66cc809d1a81cfd60cab4ba160" }
         },
         {
             name: "WoCTsc",
-            merklePath: new bsv.MerklePath(1652160, [[{ offset: 0, hash: "ee8d57d6c3f5be3238709f539dc224c44c2c848414cb5969bfa8c81c2768ad6b" }, { offset: 1, hash: "519675259eff036c6597e4a497d37c132e718171dde4ea2257e84c947ecf656b", txid: true }]]),
+            merklePath: new MerklePath(1652160, [[{ offset: 0, hash: "ee8d57d6c3f5be3238709f539dc224c44c2c848414cb5969bfa8c81c2768ad6b" }, { offset: 1, hash: "519675259eff036c6597e4a497d37c132e718171dde4ea2257e84c947ecf656b", txid: true }]]),
             header: { version: 536870912, previousHash: "0000000012dbd406fef49503c545bafd940ba2f2c9b05ef351177b71fe96e7d8", merkleRoot: "c2714feeccc7db8ea4235799e6490271867008dd39e3cf8a6e9aa20fd47f3222", time: 1734538772, bits: 474045917, nonce: 2431702809, height: 1652160, hash: "000000001c5d2b3beb2e1f1f21f69f77cb979ed92f99d2cdd1a2618349b575ca" }
         }
     ]

--- a/test/services/Services.test.ts
+++ b/test/services/Services.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from "@bsv/sdk"
+import { Beef } from "@bsv/sdk"
 import { sdk, wait } from "../../src/index.client"
 import { _tu, TestSetup1Wallet } from "../utils/TestUtilsWalletStorage"
 
@@ -106,7 +106,7 @@ describe('Wallet services tests', () => {
                     const txid = '9cce99686bc8621db439b7150dd5b3b269e4b0628fd75160222c417d6f2b95e4'
                     const rawTx = await wallet.services.getRawTx(txid)
                     const mp = await wallet.services.getMerklePath(txid)
-                    const beef = new bsv.Beef()
+                    const beef = new Beef()
                     beef.mergeBump(mp.merklePath!)
                     beef.mergeRawTx(rawTx.rawTx!)
                     // Using postTxs as postBeef is problematic still...

--- a/test/storage/update.test.ts
+++ b/test/storage/update.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { Base64String } from '@bsv/sdk'
 import { _tu, TestSetup1 } from '../utils/TestUtilsWalletStorage'
 import { sdk, StorageProvider, StorageKnex, table, verifyOne } from '../../src/index.all'
 import { log, normalizeDate, setLogging, triggerForeignKeyConstraintError, triggerUniqueConstraintError, updateTable, validateUpdateTime, verifyValues } from '../utils/testUtilsUpdate'
@@ -1687,7 +1687,7 @@ describe('update tests', () => {
             transactionId: record.transactionId,
             userId: record.userId ?? 1, // Default userId if missing
             provenTxId: 1, // Example value for update
-            reference: `updated_reference_string_${record.transactionId}==` as bsv.Base64String, // Ensure unique reference value
+            reference: `updated_reference_string_${record.transactionId}==` as Base64String, // Ensure unique reference value
             status: 'confirmed' as sdk.TransactionStatus, // Example status
             txid: `updated_txid_example_${record.transactionId}`, // Ensure unique txid
             created_at: new Date('2024-12-30T23:00:00Z'),

--- a/test/utils/TestUtilsMethodTests.ts
+++ b/test/utils/TestUtilsMethodTests.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AcquireCertificateArgs, DiscoverByAttributesArgs, DiscoverByIdentityKeyArgs, ListCertificatesArgs, ProveCertificateArgs, RelinquishCertificateArgs } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../src/index.all'
 import { Wallet } from '../../src/Wallet'
 import { jest } from '@jest/globals'
@@ -57,7 +57,7 @@ export const mockKeyDeriver = (): any => ({
  * Argument and Response Generators
  * Creates reusable test data for arguments and expected responses.
  */
-export const generateListCertificatesArgs = (overrides = {}): bsv.ListCertificatesArgs => ({
+export const generateListCertificatesArgs = (overrides = {}): ListCertificatesArgs => ({
   certifiers: [],
   types: [],
   limit: 10,
@@ -71,7 +71,7 @@ export const generateMockCertificatesResponse = (overrides = {}): any => ({
   ...overrides
 })
 
-export const generateAcquireCertificateArgs = (overrides = {}): bsv.AcquireCertificateArgs => ({
+export const generateAcquireCertificateArgs = (overrides = {}): AcquireCertificateArgs => ({
   type: 'mockType', // Base64String: A valid certificate type
   certifier: 'mockCertifier', // PubKeyHex: Certifier's public key
   acquisitionProtocol: 'direct', // AcquisitionProtocol: 'direct' or 'issuance'
@@ -91,7 +91,7 @@ export const generateMockAcquireCertificateResponse = (overrides = {}): any => (
   ...overrides
 })
 
-export const generateRelinquishCertificateArgs = (overrides = {}): bsv.RelinquishCertificateArgs => ({
+export const generateRelinquishCertificateArgs = (overrides = {}): RelinquishCertificateArgs => ({
   type: 'mockType', // Base64String: A valid certificate type
   serialNumber: 'mockSerialNumber', // Base64String: The certificate's serial number
   certifier: 'mockCertifier', // PubKeyHex: Certifier's public key
@@ -103,7 +103,7 @@ export const generateMockRelinquishCertificateResponse = (overrides = {}): any =
   ...overrides
 })
 
-export const generateProveCertificateArgs = (overrides = {}): bsv.ProveCertificateArgs => ({
+export const generateProveCertificateArgs = (overrides = {}): ProveCertificateArgs => ({
   certificate: {
     type: 'mockType',
     certifier: 'mockCertifier',
@@ -121,7 +121,7 @@ export const generateMockProveCertificateResponse = (overrides = {}): any => ({
   ...overrides
 })
 
-export const generateDiscoverByIdentityKeyArgs = (overrides = {}): bsv.DiscoverByIdentityKeyArgs => ({
+export const generateDiscoverByIdentityKeyArgs = (overrides = {}): DiscoverByIdentityKeyArgs => ({
   identityKey: 'mockIdentityKey',
   ...overrides
 })
@@ -131,7 +131,7 @@ export const generateMockDiscoverByIdentityKeyResponse = (overrides = {}): any =
   ...overrides
 })
 
-export const generateDiscoverByAttributesArgs = (overrides = {}): bsv.DiscoverByAttributesArgs => ({
+export const generateDiscoverByAttributesArgs = (overrides = {}): DiscoverByAttributesArgs => ({
   attributes: { mockAttribute: 'value' },
   ...overrides
 })

--- a/test/utils/TestUtilsWalletStorage.ts
+++ b/test/utils/TestUtilsWalletStorage.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { CreateActionArgs, CreateActionOutput, CreateActionResult, KeyDeriver, P2PKH, PrivateKey, PublicKey, SignActionArgs, SignActionResult, Utils, WalletCertificate, WalletInterface } from '@bsv/sdk'
 import path from 'path'
 import { promises as fsp } from 'fs'
 import { asArray, randomBytesBase64, randomBytesHex, sdk, StorageProvider, StorageKnex, StorageSyncReader, table, verifyTruthy, Wallet, Monitor, MonitorOptions, Services, WalletSigner, WalletStorageManager, verifyOne, StorageClient } from '../../src/index.all'
@@ -50,12 +50,12 @@ export abstract class TestUtilsWalletStorage {
     address: string,
     satoshis: number,
     noSendChange: string[] | undefined,
-    wallet: bsv.WalletInterface
+    wallet: WalletInterface
   ): Promise<{
     noSendChange: string[]
     txid: string
-    cr: bsv.CreateActionResult
-    sr: bsv.SignActionResult
+    cr: CreateActionResult
+    sr: SignActionResult
   }> {
     return await _tu.createNoSendP2PKHTestOutpoints(1, address, satoshis, noSendChange, wallet)
   }
@@ -65,14 +65,14 @@ export abstract class TestUtilsWalletStorage {
     address: string,
     satoshis: number,
     noSendChange: string[] | undefined,
-    wallet: bsv.WalletInterface
+    wallet: WalletInterface
   ): Promise<{
     noSendChange: string[]
     txid: string
-    cr: bsv.CreateActionResult
-    sr: bsv.SignActionResult
+    cr: CreateActionResult
+    sr: SignActionResult
   }> {
-    const outputs: bsv.CreateActionOutput[] = []
+    const outputs: CreateActionOutput[] = []
     for (let i = 0; i < count; i++) {
       outputs.push({
         basket: `test-p2pkh-output-${i}`,
@@ -82,7 +82,7 @@ export abstract class TestUtilsWalletStorage {
       })
     }
 
-    const createArgs: bsv.CreateActionArgs = {
+    const createArgs: CreateActionArgs = {
       description: `to ${address}`,
       outputs,
       options: {
@@ -114,7 +114,7 @@ export abstract class TestUtilsWalletStorage {
     // Spending authorization check happens here...
     //expect(st.amount > 242 && st.amount < 300).toBe(true)
     // sign and complete
-    const signArgs: bsv.SignActionArgs = {
+    const signArgs: SignActionArgs = {
       reference: st.reference,
       spends: {},
       options: {
@@ -131,23 +131,23 @@ export abstract class TestUtilsWalletStorage {
     return { noSendChange, txid, cr, sr }
   }
 
-  static getKeyPair(priv?: string | bsv.PrivateKey): TestKeyPair {
-    if (priv === undefined) priv = bsv.PrivateKey.fromRandom()
-    else if (typeof priv === 'string') priv = new bsv.PrivateKey(priv, 'hex')
+  static getKeyPair(priv?: string | PrivateKey): TestKeyPair {
+    if (priv === undefined) priv = PrivateKey.fromRandom()
+    else if (typeof priv === 'string') priv = new PrivateKey(priv, 'hex')
 
-    const pub = bsv.PublicKey.fromPrivateKey(priv)
+    const pub = PublicKey.fromPrivateKey(priv)
     const address = pub.toAddress()
     return { privateKey: priv, publicKey: pub, address }
   }
 
   static getLockP2PKH(address: string) {
-    const p2pkh = new bsv.P2PKH()
+    const p2pkh = new P2PKH()
     const lock = p2pkh.lock(address)
     return lock
   }
 
-  static getUnlockP2PKH(priv: bsv.PrivateKey, satoshis: number) {
-    const p2pkh = new bsv.P2PKH()
+  static getUnlockP2PKH(priv: PrivateKey, satoshis: number) {
+    const p2pkh = new P2PKH()
     const lock = _tu.getLockP2PKH(_tu.getKeyPair(priv).address)
     // Prepare to pay with SIGHASH_ALL and without ANYONE_CAN_PAY.
     // In otherwords:
@@ -161,9 +161,9 @@ export abstract class TestUtilsWalletStorage {
   static async createWalletOnly(args: { chain?: sdk.Chain; rootKeyHex?: string; active?: sdk.WalletStorageProvider; backups?: sdk.WalletStorageProvider[] }): Promise<TestWalletOnly> {
     args.chain ||= 'test'
     args.rootKeyHex ||= '1'.repeat(64)
-    const rootKey = bsv.PrivateKey.fromHex(args.rootKeyHex)
+    const rootKey = PrivateKey.fromHex(args.rootKeyHex)
     const identityKey = rootKey.toPublicKey().toString()
-    const keyDeriver = new bsv.KeyDeriver(rootKey)
+    const keyDeriver = new KeyDeriver(rootKey)
     const chain = args.chain
     const storage = new WalletStorageManager(identityKey, args.active, args.backups)
     if (storage.stores.length > 0) await storage.makeAvailable()
@@ -412,8 +412,8 @@ export abstract class TestUtilsWalletStorage {
     const chain: sdk.Chain = 'test'
     const rootKeyHex = _tu.legacyRootKeyHex
     const identityKey = '03ac2d10bdb0023f4145cc2eba2fcd2ad3070cb2107b0b48170c46a9440e4cc3fe'
-    const rootKey = bsv.PrivateKey.fromHex(rootKeyHex)
-    const keyDeriver = new bsv.KeyDeriver(rootKey)
+    const rootKey = PrivateKey.fromHex(rootKeyHex)
+    const keyDeriver = new KeyDeriver(rootKey)
     const activeStorage = new StorageKnex({ chain, knex: walletKnex, commissionSatoshis: 0, commissionPubKeyHex: undefined, feeModel: { model: 'sat/kb', value: 1 } })
     if (useReader) await activeStorage.dropAllData()
     await activeStorage.migrate(databaseName, identityKey)
@@ -450,14 +450,14 @@ export abstract class TestUtilsWalletStorage {
     return r
   }
 
-  static makeSampleCert(subject?: string): { cert: bsv.WalletCertificate, subject: string, certifier: bsv.PrivateKey }
+  static makeSampleCert(subject?: string): { cert: WalletCertificate, subject: string, certifier: PrivateKey }
   {
-      subject ||= bsv.PrivateKey.fromRandom().toPublicKey().toString()
-      const certifier = bsv.PrivateKey.fromRandom()
-      const verifier = bsv.PrivateKey.fromRandom()
-      const cert: bsv.WalletCertificate = {
-          type: bsv.Utils.toBase64(new Array(32).fill(1)),
-          serialNumber: bsv.Utils.toBase64(new Array(32).fill(2)),
+      subject ||= PrivateKey.fromRandom().toPublicKey().toString()
+      const certifier = PrivateKey.fromRandom()
+      const verifier = PrivateKey.fromRandom()
+      const cert: WalletCertificate = {
+          type: Utils.toBase64(new Array(32).fill(1)),
+          serialNumber: Utils.toBase64(new Array(32).fill(2)),
           revocationOutpoint: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef.1',
           subject,
           certifier: certifier.toPublicKey().toString(),
@@ -826,7 +826,7 @@ export abstract class TestUtilsWalletStorage {
   static mockPostServicesAsError(ctxs: TestWalletOnly[]): void {
     mockPostServices(ctxs, 'error')
   }
-  static mockPostServicesAsCallback(ctxs: TestWalletOnly[], callback: (beef: bsv.Beef, txids: string[]) => 'success' | 'error'): void {
+  static mockPostServicesAsCallback(ctxs: TestWalletOnly[], callback: (beef: Beef, txids: string[]) => 'success' | 'error'): void {
     mockPostServices(ctxs, 'error', callback)
   }
 
@@ -889,9 +889,9 @@ export interface TestWallet<T> extends TestWalletOnly {
   setup?: T
   userId: number
 
-  rootKey: bsv.PrivateKey
+  rootKey: PrivateKey
   identityKey: string
-  keyDeriver: bsv.KeyDeriver
+  keyDeriver: KeyDeriver
   chain: sdk.Chain
   storage: WalletStorageManager
   signer: WalletSigner
@@ -901,9 +901,9 @@ export interface TestWallet<T> extends TestWalletOnly {
 }
 
 export interface TestWalletOnly {
-  rootKey: bsv.PrivateKey
+  rootKey: PrivateKey
   identityKey: string
-  keyDeriver: bsv.KeyDeriver
+  keyDeriver: KeyDeriver
   chain: sdk.Chain
   storage: WalletStorageManager
   signer: WalletSigner
@@ -936,15 +936,15 @@ export async function expectToThrowWERR<R>(expectedClass: new (...args: any[]) =
 }
 
 export type TestKeyPair = {
-  privateKey: bsv.PrivateKey
-  publicKey: bsv.PublicKey
+  privateKey: PrivateKey
+  publicKey: PublicKey
   address: string
 }
 
-function mockPostServices(ctxs: TestWalletOnly[], status: 'success' | 'error' = 'success', callback?: (beef: bsv.Beef, txids: string[]) => 'success' | 'error'): void {
+function mockPostServices(ctxs: TestWalletOnly[], status: 'success' | 'error' = 'success', callback?: (beef: Beef, txids: string[]) => 'success' | 'error'): void {
   for (const { services } of ctxs) {
     // Mock the services postBeef to avoid actually broadcasting new transactions.
-    services.postBeef = jest.fn().mockImplementation((beef: bsv.Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
+    services.postBeef = jest.fn().mockImplementation((beef: Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
       status = !callback ? status : callback(beef, txids)
       const r: sdk.PostBeefResult = {
         name: 'mock',
@@ -953,7 +953,7 @@ function mockPostServices(ctxs: TestWalletOnly[], status: 'success' | 'error' = 
       }
       return Promise.resolve([r])
     })
-    services.postTxs = jest.fn().mockImplementation((beef: bsv.Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
+    services.postTxs = jest.fn().mockImplementation((beef: Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
       const r: sdk.PostBeefResult = {
         name: 'mock',
         status: 'success',

--- a/test/wallet/action/abortAction.test.ts
+++ b/test/wallet/action/abortAction.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { AbortActionArgs } from '@bsv/sdk'
 import { sdk } from "../../../src/index.client"
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from "../../utils/TestUtilsWalletStorage"
 
@@ -19,7 +19,7 @@ describe('abortAction tests', () => {
             ctxs.push(await _tu.createLegacyWalletMySQLCopy('abortActionTests'));
         ctxs.push(await _tu.createLegacyWalletSQLiteCopy('abortActionTests'))
         for (const { wallet } of ctxs) {
-            const invalidArgs: bsv.AbortActionArgs[] = [
+            const invalidArgs: AbortActionArgs[] = [
         { reference: '' },
         { reference: '====' },
         { reference: 'a'.repeat(301) },

--- a/test/wallet/action/createAction.test.ts
+++ b/test/wallet/action/createAction.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from '@bsv/sdk'
+import { AtomicBEEF, Beef, CreateActionArgs, SignActionArgs } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../../src/index.all'
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 
@@ -29,7 +29,7 @@ describe('createAction test', () => {
     for (const { wallet } of ctxs) {
       {
         const log = `\n${testName()}\n`
-        const args: bsv.CreateActionArgs = {
+        const args: CreateActionArgs = {
           description: ''
         }
         // description is too short...
@@ -58,10 +58,10 @@ describe('createAction test', () => {
       let txid2: string
       const outputSatoshis = 42
       let noSendChange: string[] | undefined
-      let inputBEEF: bsv.AtomicBEEF | undefined
+      let inputBEEF: AtomicBEEF | undefined
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [{ satoshis: outputSatoshis, lockingScript: _tu.getLockP2PKH(kp.address).toHex(), outputDescription: 'pay fred' }],
           options: {
@@ -84,7 +84,7 @@ describe('createAction test', () => {
         const st = cr.signableTransaction!
         expect(st.reference).toBeTruthy()
         // const tx = Transaction.fromAtomicBEEF(st.tx) // Transaction doesn't support V2 Beef yet.
-        const atomicBeef = bsv.Beef.fromBinary(st.tx)
+        const atomicBeef = Beef.fromBinary(st.tx)
         const tx = atomicBeef.txs[atomicBeef.txs.length - 1].tx
         for (const input of tx.inputs) {
           expect(atomicBeef.findTxid(input.sourceTXID!)).toBeTruthy()
@@ -94,7 +94,7 @@ describe('createAction test', () => {
         //expect(st.amount > 242 && st.amount < 300).toBe(true)
 
         // sign and complete
-        const signArgs: bsv.SignActionArgs = {
+        const signArgs: SignActionArgs = {
           reference: st.reference,
           spends: {},
           options: {
@@ -115,7 +115,7 @@ describe('createAction test', () => {
         const unlock = _tu.getUnlockP2PKH(kp.privateKey, outputSatoshis)
         const unlockingScriptLength = await unlock.estimateLength()
 
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           inputs: [
             {
@@ -141,14 +141,14 @@ describe('createAction test', () => {
         expect(cr.signableTransaction).toBeTruthy()
         const st = cr.signableTransaction!
         expect(st.reference).toBeTruthy()
-        const atomicBeef = bsv.Beef.fromBinary(st.tx)
+        const atomicBeef = Beef.fromBinary(st.tx)
         const tx = atomicBeef.txs[atomicBeef.txs.length - 1].tx
 
         tx.inputs[0].unlockingScriptTemplate = unlock
         await tx.sign()
         const unlockingScript = tx.inputs[0].unlockingScript!.toHex()
 
-        const signArgs: bsv.SignActionArgs = {
+        const signArgs: SignActionArgs = {
           reference: st.reference,
           spends: { 0: { unlockingScript } },
           options: {
@@ -162,7 +162,7 @@ describe('createAction test', () => {
         txid2 = sr.txid!
       }
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           options: {
             acceptDelayedBroadcast: false,
@@ -188,7 +188,7 @@ describe('createAction test', () => {
     const kp = _tu.getKeyPair(root.repeat(8))
 
     for (const { wallet } of ctxs) {
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Basic Transaction',
         outputs: [
           {
@@ -228,7 +228,7 @@ describe('createAction test', () => {
     const root = '02135476'
     const kp = _tu.getKeyPair(root.repeat(8))
     for (const { wallet } of ctxs) {
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Multiple Outputs',
         outputs: [
           {
@@ -273,7 +273,7 @@ describe('createAction test', () => {
     const kp = _tu.getKeyPair(root.repeat(8))
 
     for (const { wallet } of ctxs) {
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Locking Script Transaction',
         outputs: [
           {
@@ -320,7 +320,7 @@ describe('createAction test', () => {
         outputDescription: `Output ${i + 1}`
       }))
 
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Large Number of Outputs',
         outputs,
         options: {
@@ -359,7 +359,7 @@ describe('createAction test', () => {
         }
       ]
 
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Randomized Outputs',
         outputs,
         options: {
@@ -388,7 +388,7 @@ describe('createAction test', () => {
     const kp = _tu.getKeyPair(root.repeat(8))
 
     for (const { wallet } of ctxs) {
-      const args: bsv.CreateActionArgs = {
+      const args: CreateActionArgs = {
         description: 'Lock Time Transaction',
         outputs: [
           {

--- a/test/wallet/action/createActionbob1.test.ts
+++ b/test/wallet/action/createActionbob1.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from '@bsv/sdk'
+import { Beef, CreateActionArgs, SignActionArgs } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../../src/index.all'
 
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
@@ -21,7 +21,7 @@ describe.skip('createActionbob1 test', () => {
     ctxs.push(await _tu.createLegacyWalletSQLiteCopy('createActionTests'))
     for (const { services } of ctxs) {
       // Mock the services postBeef to avoid actually broadcasting new transactions.
-      services.postBeef = jest.fn().mockImplementation((beef: bsv.Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
+      services.postBeef = jest.fn().mockImplementation((beef: Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
         const r: sdk.PostBeefResult = {
           name: 'mock',
           status: 'success',
@@ -29,7 +29,7 @@ describe.skip('createActionbob1 test', () => {
         }
         return Promise.resolve([r])
       })
-      services.postTxs = jest.fn().mockImplementation((beef: bsv.Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
+      services.postTxs = jest.fn().mockImplementation((beef: Beef, txids: string[]): Promise<sdk.PostBeefResult[]> => {
         const r: sdk.PostBeefResult = {
           name: 'mock',
           status: 'success',
@@ -50,7 +50,7 @@ describe.skip('createActionbob1 test', () => {
     for (const { wallet } of ctxs) {
       {
         const log = `\n${testName()}\n`
-        const args: bsv.CreateActionArgs = {
+        const args: CreateActionArgs = {
           description: ''
         }
         // description is too short...
@@ -81,7 +81,7 @@ describe.skip('createActionbob1 test', () => {
       let noSendChange: string[] | undefined
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [{ satoshis: outputSatoshis, lockingScript: _tu.getLockP2PKH(kp.address).toHex(), outputDescription: 'pay fred' }],
           options: {
@@ -103,7 +103,7 @@ describe.skip('createActionbob1 test', () => {
         const st = cr.signableTransaction!
         //expect(st.reference).toBeTruthy()
         // const tx = Transaction.fromAtomicBEEF(st.tx) // Transaction doesn't support V2 Beef yet.
-        const atomicBeef = bsv.Beef.fromBinary(st.tx)
+        const atomicBeef = Beef.fromBinary(st.tx)
         const tx = atomicBeef.txs[atomicBeef.txs.length - 1].tx
         for (const input of tx.inputs) {
           expect(atomicBeef.findTxid(input.sourceTXID!)).toBeTruthy()
@@ -113,7 +113,7 @@ describe.skip('createActionbob1 test', () => {
         //expect(st.amount > 242 && st.amount < 300).toBe(true)
 
         // sign and complete
-        const signArgs: bsv.SignActionArgs = {
+        const signArgs: SignActionArgs = {
           reference: st.reference,
           spends: {},
           options: {
@@ -133,7 +133,7 @@ describe.skip('createActionbob1 test', () => {
         const unlock = _tu.getUnlockP2PKH(kp.privateKey, outputSatoshis)
         const unlockingScriptLength = await unlock.estimateLength()
 
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           inputs: [
             {
@@ -157,14 +157,14 @@ describe.skip('createActionbob1 test', () => {
         expect(cr.signableTransaction).toBeTruthy()
         const st = cr.signableTransaction!
         expect(st.reference).toBeTruthy()
-        const atomicBeef = bsv.Beef.fromBinary(st.tx)
+        const atomicBeef = Beef.fromBinary(st.tx)
         const tx = atomicBeef.txs[atomicBeef.txs.length - 1].tx
 
         tx.inputs[0].unlockingScriptTemplate = unlock
         await tx.sign()
         const unlockingScript = tx.inputs[0].unlockingScript!.toHex()
 
-        const signArgs: bsv.SignActionArgs = {
+        const signArgs: SignActionArgs = {
           reference: st.reference,
           spends: { 0: { unlockingScript } },
           options: {
@@ -178,7 +178,7 @@ describe.skip('createActionbob1 test', () => {
         txid2 = sr.txid!
       }
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           options: {
             sendWith: [txid1, txid2]

--- a/test/wallet/action/internalizeAction.test.ts
+++ b/test/wallet/action/internalizeAction.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { CreateActionArgs, InternalizeActionArgs, P2PKH, WalletProtocol } from '@bsv/sdk'
 import { sdk } from '../../../src/index.all'
 import { _tu, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 
@@ -37,7 +37,7 @@ describe('internalizeAction tests', () => {
       const outputSatoshis = 4
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [{ satoshis: outputSatoshis, lockingScript: _tu.getLockP2PKH(fredsAddress).toHex(), outputDescription: 'pay fred' }],
           options: {
@@ -55,7 +55,7 @@ describe('internalizeAction tests', () => {
         const fred = await _tu.createSQLiteTestWallet({ chain: 'test', databaseName: 'internalizeAction1fred', rootKeyHex: '2'.repeat(64), dropAll: true })
 
         // Internalize args to add fred's new output to his own wallet
-        const internalizeArgs: bsv.InternalizeActionArgs = {
+        const internalizeArgs: InternalizeActionArgs = {
           tx: cr.tx!,
           outputs: [
             {
@@ -117,7 +117,7 @@ describe('internalizeAction tests', () => {
       const outputSatoshis2 = 5
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `${kp.address} of ${root}`,
           outputs: [
             { satoshis: outputSatoshis1, lockingScript: _tu.getLockP2PKH(fredsAddress).toHex(), outputDescription: 'pay fred 1st payment' },
@@ -138,7 +138,7 @@ describe('internalizeAction tests', () => {
         const fred = await _tu.createSQLiteTestWallet({ chain: 'test', databaseName: 'internalizeAction2fred', rootKeyHex: '2'.repeat(64), dropAll: true })
 
         // Internalize args to add fred's new output to his own wallet
-        const internalizeArgs: bsv.InternalizeActionArgs = {
+        const internalizeArgs: InternalizeActionArgs = {
           tx: cr.tx!,
           outputs: [
             {
@@ -219,17 +219,17 @@ describe('internalizeAction tests', () => {
       const outputSatoshis = 5
       const derivationPrefix = Buffer.from('invoice-12345').toString('base64')
       const derivationSuffix = Buffer.from('utxo-0').toString('base64')
-      const brc29ProtocolID: bsv.WalletProtocol = [2, '3241645161d8']
+      const brc29ProtocolID: WalletProtocol = [2, '3241645161d8']
       const derivedPublicKey = wallet.signer.keyDeriver.derivePublicKey(brc29ProtocolID, `${derivationPrefix} ${derivationSuffix}`, fred.identityKey)
       const derivedAddress = derivedPublicKey.toAddress()
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `description BRC-29`,
           outputs: [
             {
               satoshis: outputSatoshis,
-              lockingScript: new bsv.P2PKH().lock(derivedAddress).toHex(),
+              lockingScript: new P2PKH().lock(derivedAddress).toHex(),
               outputDescription: 'pay fred BRC-29'
             }
           ],
@@ -244,7 +244,7 @@ describe('internalizeAction tests', () => {
         const cr = await wallet.createAction(createArgs)
         expect(cr.tx).toBeTruthy()
 
-        const internalizeArgs: bsv.InternalizeActionArgs = {
+        const internalizeArgs: InternalizeActionArgs = {
           tx: cr.tx!,
           outputs: [
             {
@@ -296,7 +296,7 @@ describe('internalizeAction tests', () => {
     for (const { wallet, identityKey: senderIdentityKey } of ctxs) {
       const fred = await _tu.createSQLiteTestWallet({ chain: 'test', databaseName: 'internalizeAction4fred', rootKeyHex: '2'.repeat(64), dropAll: true })
 
-      const brc29ProtocolID: bsv.WalletProtocol = [2, '3241645161d8']
+      const brc29ProtocolID: WalletProtocol = [2, '3241645161d8']
       const outputSatoshis1 = 6
       const derivationPrefix = Buffer.from('invoice-12345').toString('base64')
       const derivationSuffix1 = Buffer.from('utxo-1').toString('base64')
@@ -309,17 +309,17 @@ describe('internalizeAction tests', () => {
       const derivedAddress2 = derivedPublicKey2.toAddress()
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `BRC-29 payments from other wallet`,
           outputs: [
             {
               satoshis: outputSatoshis1,
-              lockingScript: new bsv.P2PKH().lock(derivedAddress1).toHex(),
+              lockingScript: new P2PKH().lock(derivedAddress1).toHex(),
               outputDescription: 'pay fred 1st BRC-29 payment'
             },
             {
               satoshis: outputSatoshis2,
-              lockingScript: new bsv.P2PKH().lock(derivedAddress2).toHex(),
+              lockingScript: new P2PKH().lock(derivedAddress2).toHex(),
               outputDescription: 'pay fred 2nd BRC-29 payment'
             }
           ],
@@ -334,7 +334,7 @@ describe('internalizeAction tests', () => {
         const cr = await wallet.createAction(createArgs)
         expect(cr.tx).toBeTruthy()
 
-        const internalizeArgs: bsv.InternalizeActionArgs = {
+        const internalizeArgs: InternalizeActionArgs = {
           tx: cr.tx!,
           outputs: [
             {
@@ -395,7 +395,7 @@ describe('internalizeAction tests', () => {
     for (const { wallet, identityKey: senderIdentityKey } of ctxs) {
       const fred = await _tu.createSQLiteTestWallet({ chain: 'test', databaseName: 'internalizeAction5fred', rootKeyHex: '2'.repeat(64), dropAll: true })
 
-      const brc29ProtocolID: bsv.WalletProtocol = [2, '3241645161d8']
+      const brc29ProtocolID: WalletProtocol = [2, '3241645161d8']
       const outputSatoshis1 = 8
       const derivationPrefix = Buffer.from('invoice-12345').toString('base64')
       const derivationSuffix1 = Buffer.from('utxo-1').toString('base64')
@@ -415,17 +415,17 @@ describe('internalizeAction tests', () => {
       const outputSatoshis4 = 11
 
       {
-        const createArgs: bsv.CreateActionArgs = {
+        const createArgs: CreateActionArgs = {
           description: `BRC-29 payments from other wallet`,
           outputs: [
             {
               satoshis: outputSatoshis1,
-              lockingScript: new bsv.P2PKH().lock(derivedAddress1).toHex(),
+              lockingScript: new P2PKH().lock(derivedAddress1).toHex(),
               outputDescription: 'pay fred 1st BRC-29 payment'
             },
             {
               satoshis: outputSatoshis2,
-              lockingScript: new bsv.P2PKH().lock(derivedAddress2).toHex(),
+              lockingScript: new P2PKH().lock(derivedAddress2).toHex(),
               outputDescription: 'pay fred 2nd BRC-29 payment'
             },
             {
@@ -450,7 +450,7 @@ describe('internalizeAction tests', () => {
         const cr = await wallet.createAction(createArgs)
         expect(cr.tx).toBeTruthy()
 
-        const internalizeArgs: bsv.InternalizeActionArgs = {
+        const internalizeArgs: InternalizeActionArgs = {
           tx: cr.tx!,
 
           outputs: [

--- a/test/wallet/action/relinquishOutput.test.ts
+++ b/test/wallet/action/relinquishOutput.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { RelinquishOutputArgs } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../../src/index.all'
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 import { getBeefForTransaction } from '../../../src/storage/methods/getBeefForTransaction'
@@ -25,7 +25,7 @@ describe('RelinquishOutputArgs tests', () => {
     const expectedResult = { relinquished: true }
 
     for (const { wallet, activeStorage: storage } of ctxs) {
-      const args: bsv.RelinquishOutputArgs = {
+      const args: RelinquishOutputArgs = {
         basket: 'default',
         output: `${outputTxid}.0`
       }

--- a/test/wallet/construct/Wallet.constructor.test.ts
+++ b/test/wallet/construct/Wallet.constructor.test.ts
@@ -1,4 +1,3 @@
-import * as bsv from "@bsv/sdk"
 import { sdk } from "../../../src/index.client"
 import { _tu, TestSetup1Wallet } from "../../utils/TestUtilsWalletStorage"
 

--- a/test/wallet/list/listActions.test.ts
+++ b/test/wallet/list/listActions.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { ListActionsArgs } from '@bsv/sdk'
 import { sdk } from "../../../src/index.client"
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from "../../utils/TestUtilsWalletStorage"
 
@@ -22,7 +22,7 @@ describe('listActions tests', () => {
 
     test('0 invalid params', async () => {
         for (const { wallet } of ctxs) {
-            const invalidArgs: bsv.ListActionsArgs[] = [
+            const invalidArgs: ListActionsArgs[] = [
                 { labels: ['toolong890'.repeat(31)] },
                 // Oh so many things to test...
             ]
@@ -36,7 +36,7 @@ describe('listActions tests', () => {
     test('1 all actions', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeLabels: true,
                     labels: []
                 }
@@ -56,7 +56,7 @@ describe('listActions tests', () => {
     test('3_label babbage_protocol_perm', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeLabels: true,
                     labels: ['babbage_protocol_perm']
                 }
@@ -77,7 +77,7 @@ describe('listActions tests', () => {
     test('4_label babbage_protocol_perm', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeLabels: true,
                     labels: ['babbage_protocol_perm']
                 }
@@ -100,7 +100,7 @@ describe('listActions tests', () => {
     test('5_label babbage_protocol_perm or babbage_basket_access', async () => {
         for (const { wallet } of ctxs) {
         {
-            const args: bsv.ListActionsArgs = {
+            const args: ListActionsArgs = {
                 includeLabels: true,
                 labels: ['babbage_protocol_perm', 'babbage_basket_access']
             }
@@ -125,7 +125,7 @@ describe('listActions tests', () => {
     test('6_label babbage_protocol_perm and babbage_basket_access', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeLabels: true,
                     labels: ['babbage_protocol_perm', 'babbage_basket_access'],
                     labelQueryMode: 'all'
@@ -139,7 +139,7 @@ describe('listActions tests', () => {
     test('7_includeOutputs', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeOutputs: true,
                     labels: ['babbage_protocol_perm']
                 }
@@ -164,7 +164,7 @@ describe('listActions tests', () => {
     test('8_includeOutputs and script', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeOutputs: true,
                     includeOutputLockingScripts: true,
                     labels: ['babbage_protocol_perm']
@@ -183,7 +183,7 @@ describe('listActions tests', () => {
     test('9_includeInputs', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeInputs: true,
                     labels: ['babbage_protocol_perm']
                 }
@@ -206,7 +206,7 @@ describe('listActions tests', () => {
     test('10_includeInputs and unlock', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeInputs: true,
                     includeInputUnlockingScripts: true,
                     labels: ['babbage_protocol_perm']
@@ -230,7 +230,7 @@ describe('listActions tests', () => {
     test('11_includeInputs and lock', async () => {
         for (const { wallet } of ctxs) {
             {
-                const args: bsv.ListActionsArgs = {
+                const args: ListActionsArgs = {
                     includeInputs: true,
                     includeInputSourceLockingScripts: true,
                     labels: ['babbage_protocol_perm']

--- a/test/wallet/list/listCertificates.test.ts
+++ b/test/wallet/list/listCertificates.test.ts
@@ -1,4 +1,4 @@
-import * as bsv from '@bsv/sdk'
+import { ListCertificatesArgs } from '@bsv/sdk'
 import { sdk } from "../../../src/index.client"
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from "../../utils/TestUtilsWalletStorage"
 
@@ -23,7 +23,7 @@ describe('listCertificates tests', () => {
     test('0 invalid params', async () => {
         for (const { wallet } of ctxs) {
 
-            const invalidArgs: bsv.ListCertificatesArgs[] = [
+            const invalidArgs: ListCertificatesArgs[] = [
                 {
                     certifiers: ['thisisnotbase64'],
                     types: []
@@ -40,7 +40,7 @@ describe('listCertificates tests', () => {
     test('1 certifier', async () => {
         for (const { wallet } of ctxs) {
 
-            const tcs: { args: bsv.ListCertificatesArgs, count: number }[] = [
+            const tcs: { args: ListCertificatesArgs, count: number }[] = [
                 { args: { certifiers: ['02cf6cdf466951d8dfc9e7c9367511d0007ed6fba35ed42d425cc412fd6cfd4a17'], types: [], limit: 1 }, count: 4 },
                 { args: { certifiers: ['02CF6CDF466951D8DFC9E7C9367511D0007ED6FBA35ED42D425CC412FD6CFD4A17'], types: [], limit: 10 }, count: 4 },
                 { args: { certifiers: [
@@ -59,7 +59,7 @@ describe('listCertificates tests', () => {
 
     test('2 types', async () => {
         for (const { wallet } of ctxs) {
-            const tcs: { args: bsv.ListCertificatesArgs, count: number }[] = [
+            const tcs: { args: ListCertificatesArgs, count: number }[] = [
                 { args: { certifiers: [], types: ['exOl3KM0dIJ04EW5pZgbZmPag6MdJXd3/a1enmUU/BA='], limit: 1 }, count: 2 },
                 { args: { certifiers: [], types: ['exOl3KM0dIJ04EW5pZgbZmPag6MdJXd3/a1enmUU/BA='], limit: 10 }, count: 2 },
                 {

--- a/test/wallet/list/listOutputs.test.ts
+++ b/test/wallet/list/listOutputs.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as bsv from '@bsv/sdk'
+import { BasketStringUnder300Bytes, Beef, ListOutputsArgs, ListOutputsResult, OriginatorDomainNameStringUnder250Bytes, OutputTagStringUnder300Bytes } from '@bsv/sdk'
 import { sdk, StorageKnex } from '../../../src/index.all'
 import { _tu, expectToThrowWERR, TestWalletNoSetup } from '../../utils/TestUtilsWalletStorage'
 
@@ -24,7 +24,7 @@ describe('listOutputs test', () => {
       await ctx.storage.destroy()
     }
   })
-  const logResult = (r: bsv.ListOutputsResult): string => {
+  const logResult = (r: ListOutputsResult): string => {
     const truncate = (s: string) => (s.length > 80 ? s.slice(0, 77) + '...' : s)
 
     let log = `totalOutputs=${r.totalOutputs} outputs=${r.outputs.length}\n`
@@ -37,7 +37,7 @@ describe('listOutputs test', () => {
       if (o.lockingScript) log += `  lockingScript: ${o.lockingScript.length} ${truncate(o.lockingScript)}\n`
     }
     if (r.BEEF) {
-      const beef = bsv.Beef.fromBinary(r.BEEF)
+      const beef = Beef.fromBinary(r.BEEF)
       log += `BEEF:\n`
       log += beef.toLogString()
     }
@@ -46,11 +46,11 @@ describe('listOutputs test', () => {
 
   test('0 invalid params with originator', async () => {
     for (const { wallet } of ctxs) {
-      const invalidArgs: bsv.ListOutputsArgs[] = [
+      const invalidArgs: ListOutputsArgs[] = [
         { basket: 'default', tags: [] },
-        { basket: '' as bsv.BasketStringUnder300Bytes },
-        { basket: '   ' as bsv.BasketStringUnder300Bytes },
-        { basket: 'default', tags: [''] as bsv.OutputTagStringUnder300Bytes[] },
+        { basket: '' as BasketStringUnder300Bytes },
+        { basket: '   ' as BasketStringUnder300Bytes },
+        { basket: 'default', tags: [''] as OutputTagStringUnder300Bytes[] },
         { basket: 'default', limit: 0 },
         { basket: 'default', limit: -1 },
         { basket: 'default', limit: 10001 },
@@ -69,7 +69,7 @@ describe('listOutputs test', () => {
         for (const originator of invalidOriginators) {
           if (!noLog) console.log('Testing args:', args, 'with originator:', originator)
           try {
-            await wallet.listOutputs(args, originator as bsv.OriginatorDomainNameStringUnder250Bytes)
+            await wallet.listOutputs(args, originator as OriginatorDomainNameStringUnder250Bytes)
             throw new Error('Expected method to throw.')
           } catch (e) {
             const error = e as Error
@@ -88,9 +88,9 @@ describe('listOutputs test', () => {
 
   test('1 valid params with originator', async () => {
     for (const { wallet } of ctxs) {
-      const validArgs: bsv.ListOutputsArgs = {
-        basket: 'default' as bsv.BasketStringUnder300Bytes,
-        tags: ['tag1', 'tag2'] as bsv.OutputTagStringUnder300Bytes[],
+      const validArgs: ListOutputsArgs = {
+        basket: 'default' as BasketStringUnder300Bytes,
+        tags: ['tag1', 'tag2'] as OutputTagStringUnder300Bytes[],
         limit: 10,
         offset: 0,
         tagQueryMode: 'any',
@@ -105,7 +105,7 @@ describe('listOutputs test', () => {
 
       for (const originator of validOriginators) {
         if (!noLog) console.log('Testing args:', validArgs, 'with originator:', originator)
-        const result = await wallet.listOutputs(validArgs, originator as bsv.OriginatorDomainNameStringUnder250Bytes)
+        const result = await wallet.listOutputs(validArgs, originator as OriginatorDomainNameStringUnder250Bytes)
         if (!noLog) console.log('Result:', result)
         expect(result.totalOutputs).toBeGreaterThanOrEqual(0)
       }
@@ -116,7 +116,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default'
         }
         const r = await wallet.listOutputs(args)
@@ -139,12 +139,12 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default'
         }
         const validOriginators = ['example.com', 'localhost', 'subdomain.example.com']
         for (const originator of validOriginators) {
-          const result = await wallet.listOutputs(args, originator as bsv.OriginatorDomainNameStringUnder250Bytes)
+          const result = await wallet.listOutputs(args, originator as OriginatorDomainNameStringUnder250Bytes)
         }
         const r = await wallet.listOutputs(args)
         log += logResult(r)
@@ -166,7 +166,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default',
           includeTags: true,
           includeLabels: true,
@@ -188,7 +188,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default',
           include: 'locking scripts',
           limit: 100
@@ -207,7 +207,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default'
         }
         const r = await wallet.listOutputs(args)
@@ -224,7 +224,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'non-existent-basket',
           tags: ['babbage_action_originator projectbabbage.com'],
           includeTags: true
@@ -238,7 +238,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'babbage-protocol-permission',
           tags: ['babbage_action_originator projectbabbage.com'],
           includeTags: true
@@ -258,14 +258,14 @@ describe('listOutputs test', () => {
     for (const { wallet, services } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'default',
           include: 'entire transactions'
         }
         const r = await wallet.listOutputs(args)
         log += logResult(r)
         expect(r.BEEF).toBeTruthy()
-        expect(await bsv.Beef.fromBinary(r.BEEF || []).verify(await services.getChainTracker())).toBe(true)
+        expect(await Beef.fromBinary(r.BEEF || []).verify(await services.getChainTracker())).toBe(true)
         if (!noLog) console.log(log)
       }
     }
@@ -275,7 +275,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'babbage-protocol-permission',
           includeLabels: true,
           limit: 5
@@ -298,7 +298,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'babbage-token-access',
           includeTags: true,
           limit: 15
@@ -323,7 +323,7 @@ describe('listOutputs test', () => {
     for (const { wallet } of ctxs) {
       {
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'babbage-protocol-permission',
           includeTags: true,
           tags: ['babbage_protocolsecuritylevel 2']
@@ -350,7 +350,7 @@ describe('listOutputs test', () => {
   test('12_tags babbage-token-access all', async () => {
     for (const { wallet } of ctxs) {
       let log = `\n${testName()}\n`
-      const args: bsv.ListOutputsArgs = {
+      const args: ListOutputsArgs = {
         basket: 'babbage-token-access',
         includeTags: true,
         tags: ['babbage_basket todo tokens', 'babbage_action_originator projectbabbage.com', 'babbage_originator localhost:8088'], // Match all actual output tags
@@ -382,7 +382,7 @@ describe('listOutputs test', () => {
         const storage = ctxs[0].activeStorage as StorageKnex
         prepareDatabaseCustomInstrctions(storage)
         let log = `\n${testName()}\n`
-        const args: bsv.ListOutputsArgs = {
+        const args: ListOutputsArgs = {
           basket: 'todo tokens',
           includeTags: true,
           includeLabels: true,


### PR DESCRIPTION
All uses of 'import * as bsv from "@bsv/sdk"' have been removed.
Replaced by lists of actually required symbols.
Transaction => BsvTransaction
Certificate => BsvCertificate