### PR TITLE
Fix/metadata encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox",
-      "version": "1.2.28",
+      "version": "1.2.29",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/auth-express-middleware": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "description": "BRC100 conforming wallet, wallet storage and wallet signer components",
   "main": "./out/src/index.js",
   "types": "./out/src/index.d.ts",

--- a/src/WalletPermissionsManager.ts
+++ b/src/WalletPermissionsManager.ts
@@ -951,7 +951,7 @@ export class WalletPermissionsManager implements WalletInterface {
       },
       this.adminOriginator
     )
-    return Utils.toUTF8(ciphertext) // Still a string, but scrambled.
+    return Utils.toBase64(ciphertext) // Still a string, but scrambled.
   }
 
   /**
@@ -963,7 +963,7 @@ export class WalletPermissionsManager implements WalletInterface {
     try {
       const { plaintext } = await this.underlying.decrypt(
         {
-          ciphertext: Utils.toArray(ciphertext, 'utf8'),
+          ciphertext: Utils.toArray(ciphertext, 'base64'),
           protocolID: WalletPermissionsManager.METADATA_ENCRYPTION_PROTOCOL,
           keyID: '1'
         },

--- a/src/WalletPermissionsManager.ts
+++ b/src/WalletPermissionsManager.ts
@@ -1,4 +1,4 @@
-import { WalletInterface, Utils, PushDrop, LockingScript, Transaction, WalletProtocol } from '@bsv/sdk'
+import { WalletInterface, Utils, PushDrop, LockingScript, Transaction, WalletProtocol, Base64String } from '@bsv/sdk'
 import { validateCreateActionArgs } from './sdk'
 
 ////// TODO: ADD SUPPORT FOR ADMIN COUNTERPARTIES BASED ON WALLET STORAGE
@@ -939,7 +939,7 @@ export class WalletPermissionsManager implements WalletInterface {
    * @param plaintext The metadata to encrypt if configured to do so
    * @returns The encrypted metadata, or the original value if encryption was disabled.
    */
-  private async maybeEncryptMetadata(plaintext: string): Promise<string> {
+  private async maybeEncryptMetadata(plaintext: string): Promise<Base64String> {
     if (!this.config.encryptWalletMetadata) {
       return plaintext
     }
@@ -951,7 +951,7 @@ export class WalletPermissionsManager implements WalletInterface {
       },
       this.adminOriginator
     )
-    return Utils.toBase64(ciphertext) // Still a string, but scrambled.
+    return Utils.toBase64(ciphertext)
   }
 
   /**
@@ -959,7 +959,7 @@ export class WalletPermissionsManager implements WalletInterface {
    * @param ciphertext The metadata to attempt decryption for.
    * @returns The decrypted metadata. If decryption fails, returns the original value instead.
    */
-  private async maybeDecryptMetadata(ciphertext: string): Promise<string> {
+  private async maybeDecryptMetadata(ciphertext: Base64String): Promise<string> {
     try {
       const { plaintext } = await this.underlying.decrypt(
         {

--- a/src/__tests/WalletPermissionsManager.encryption.test.ts
+++ b/src/__tests/WalletPermissionsManager.encryption.test.ts
@@ -1,6 +1,7 @@
 import { mockUnderlyingWallet, MockedBSV_SDK } from './WalletPermissionsManager.fixtures'
 import { WalletPermissionsManager } from '../WalletPermissionsManager'
 import { jest } from '@jest/globals'
+import { Utils } from '@bsv/sdk'
 
 jest.mock('@bsv/sdk', () => MockedBSV_SDK)
 
@@ -62,7 +63,7 @@ describe('WalletPermissionsManager - Metadata Encryption & Decryption', () => {
         plaintext: [72, 105] // 'Hi'
       })
 
-      const ciphertext = 'random-string-representing-ciphertext'
+      const ciphertext = Utils.toBase64(Utils.toArray('random-string-representing-ciphertext'))
       const result = await manager['maybeDecryptMetadata'](ciphertext)
 
       // We expect underlying.decrypt() to have been called
@@ -153,19 +154,19 @@ describe('WalletPermissionsManager - Metadata Encryption & Decryption', () => {
         totalActions: 1,
         actions: [
           {
-            description: 'fake-encrypted-string-for-description',
+            description: Utils.toBase64(Utils.toArray('fake-encrypted-string-for-description')),
             inputs: [
               {
                 outpoint: 'txid1.0',
-                inputDescription: 'fake-encrypted-string-for-inputDesc'
+                inputDescription: Utils.toBase64(Utils.toArray('fake-encrypted-string-for-inputDesc'))
               }
             ],
             outputs: [
               {
                 lockingScript: 'OP_RETURN 1234',
                 satoshis: 500,
-                outputDescription: 'fake-encrypted-string-for-outputDesc',
-                customInstructions: 'fake-encrypted-string-for-customInstr'
+                outputDescription: Utils.toBase64(Utils.toArray('fake-encrypted-string-for-outputDesc')),
+                customInstructions: Utils.toBase64(Utils.toArray('fake-encrypted-string-for-customInstr'))
               }
             ]
           }
@@ -268,7 +269,7 @@ describe('WalletPermissionsManager - Metadata Encryption & Decryption', () => {
       // To simulate, we make decryption pass through.
       underlying.decrypt.mockImplementation(x => x)
       const listResult = await (manager as any).listActions({}, 'nonadmin.com')
-      expect(underlying.decrypt).toHaveBeenCalledTimes(4)
+      expect(underlying.decrypt).toHaveBeenCalledTimes(3)
 
       // Confirm the returned data is the same as originally provided (plaintext)
       const [first] = listResult.actions
@@ -297,7 +298,7 @@ describe('WalletPermissionsManager - Metadata Encryption & Decryption', () => {
             satoshis: 999,
             lockingScript: 'OP_RETURN something',
             basket: 'some-basket',
-            customInstructions: 'fake-encrypted-instructions-string'
+            customInstructions: Utils.toBase64(Utils.toArray('fake-encrypted-instructions-string'))
           }
         ]
       })

--- a/src/__tests/WalletPermissionsManager.fixtures.ts
+++ b/src/__tests/WalletPermissionsManager.fixtures.ts
@@ -20,7 +20,7 @@ export class MockTransaction {
   public outputs: any[] = []
   public fee: number = 0
 
-  constructor() {}
+  constructor() { }
   static fromAtomicBEEF() {
     // Mocked below
   }
@@ -35,7 +35,7 @@ export class MockTransaction {
   }
 }
 
-;(MockTransaction as any).fromAtomicBEEF = jest.fn(() => {
+; (MockTransaction as any).fromAtomicBEEF = jest.fn(() => {
   // We skip real validation, returning a MockTransaction with minimal structure.
   const tx = new MockTransaction()
   return tx
@@ -153,6 +153,12 @@ export const MockUtils = {
   toUTF8: (arr: number[]) => {
     // Converts an array of numbers to a UTF-8 string.
     return String.fromCharCode(...arr)
+  },
+
+  toBase64: (arr: number[]) => {
+    // Converts an array of numbers to a Base64 string.
+    const binaryStr = String.fromCharCode(...arr)
+    return btoa(binaryStr)
   }
 }
 

--- a/src/__tests/WalletPermissionsManager.fixtures.ts
+++ b/src/__tests/WalletPermissionsManager.fixtures.ts
@@ -20,7 +20,7 @@ export class MockTransaction {
   public outputs: any[] = []
   public fee: number = 0
 
-  constructor() { }
+  constructor() {}
   static fromAtomicBEEF() {
     // Mocked below
   }
@@ -35,7 +35,7 @@ export class MockTransaction {
   }
 }
 
-; (MockTransaction as any).fromAtomicBEEF = jest.fn(() => {
+;(MockTransaction as any).fromAtomicBEEF = jest.fn(() => {
   // We skip real validation, returning a MockTransaction with minimal structure.
   const tx = new MockTransaction()
   return tx


### PR DESCRIPTION
## Description of Changes

- Refactored create action metadata encryption to store the ciphertext as base64 instead of utf-8 to prevent data corruption.
- When testing listActions, metadata decryption was failing due to this problem.
