### PR TITLE
Fix consuming UMP to preserve identity and create new token

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox-client",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox-client",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/sdk": "^1.4.20"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox-client",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Client only Wallet Storage",
   "main": "./out/src/index.client.js",
   "types": "./out/src/index.client.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/wallet-toolbox",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/auth-express-middleware": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/wallet-toolbox",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "BRC100 conforming wallet, wallet storage and wallet signer components",
   "main": "./out/src/index.js",
   "types": "./out/src/index.d.ts",

--- a/src/CWIStyleWalletManager.ts
+++ b/src/CWIStyleWalletManager.ts
@@ -338,12 +338,19 @@ export class OverlayUMPTokenInteractor implements UMPTokenInteractor {
     const inputs: CreateActionInput[] = []
     let inputToken: { beef: number[]; outputIndex: number } | undefined
     if (oldTokenToConsume?.currentOutpoint) {
-      inputs.push({
-        outpoint: oldTokenToConsume.currentOutpoint,
-        unlockingScriptLength: 73, // typical signature length
-        inputDescription: 'Consume old UMP token'
-      })
       inputToken = await this.findByOutpoint(oldTokenToConsume.currentOutpoint)
+      // If there is no token on the overlay, we can't consume it. Just start over with a new token.
+      if (!inputToken) {
+        oldTokenToConsume = undefined
+
+      // Otherwise, add the input
+      } else {
+        inputs.push({
+          outpoint: oldTokenToConsume.currentOutpoint,
+          unlockingScriptLength: 73, // typical signature length
+          inputDescription: 'Consume old UMP token'
+        })
+      }
     }
 
     const outputs = [


### PR DESCRIPTION
## Description of Changes

UMP tokens are consumed and re-created if not on the overlay; this allows a user to "start over" with a new UMP token, if for some reason their token was evicted from the overlay.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged