### PR TITLE
[ FEATURE ] Add optional support for BlockHeadersService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@bsv/auth-express-middleware": "^1.1.2",
         "@bsv/payment-express-middleware": "^1.0.6",
-        "@bsv/sdk": "^1.6.0",
+        "@bsv/sdk": "^1.6.5",
         "express": "^4.21.2",
         "idb": "^8.0.2",
         "knex": "^3.1.0",
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.0.tgz",
-      "integrity": "sha512-4RpYgiN+pLKohXLaO0p1tnYRJ6UF59ItVsu1qtazHzaawoIOhfxkvbnKvznHQCdcJkGPtT1EFKZFiheqXnt7sQ==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.5.tgz",
+      "integrity": "sha512-2TPtRgC+uxTM8dKqFyGuStdsS35VELM121wpfskr72TO5d6l+CcpMt/aho4X19Flxx47YmTXuCin85Kof0W7Cw==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1453,7 +1453,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2280,7 +2282,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3389,7 +3393,9 @@
       }
     },
     "node_modules/jest-simple-summary": {
-      "version": "v1.0.2",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-simple-summary/-/jest-simple-summary-1.0.2.tgz",
+      "integrity": "sha512-lYg30USp6YB5eiMIhWprJdMDjxy4apjFZb9Rdpwe5/um5xyJE6GAZVhlK0wqxTTLhYaHz1Gej1DAUFVQzvvPow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5145,7 +5151,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@bsv/auth-express-middleware": "^1.1.2",
     "@bsv/payment-express-middleware": "^1.0.6",
-    "@bsv/sdk": "^1.6.0",
+    "@bsv/sdk": "^1.6.5",
     "express": "^4.21.2",
     "idb": "^8.0.2",
     "knex": "^3.1.0",

--- a/src/Setup.ts
+++ b/src/Setup.ts
@@ -26,6 +26,8 @@ import {
 import { Knex, knex as makeKnex } from 'knex'
 
 import * as dotenv from 'dotenv'
+// To rely on your own headers service, uncomment the following line:
+// import { BHServiceClient } from './services/chaintracker'
 dotenv.config()
 
 /**
@@ -145,6 +147,10 @@ DEV_KEYS = '{
     if (storage.canMakeAvailable()) await storage.makeAvailable()
     const serviceOptions = Services.createDefaultOptions(chain)
     serviceOptions.taalApiKey = args.env.taalApiKey
+
+    // To rely on your own headers service, uncomment the following line, updating the url and apiKey to your own values.
+    // serviceOptions.chaintracks = new BHServiceClient('main', { url: 'https://headers.spv.money', apiKey: 'fC42F069YJs30FaWBAgikfDFEfIW1j4q' })
+    
     const services = new Services(serviceOptions)
     const monopts = Monitor.createDefaultWalletMonitorOptions(chain, storage, services)
     const monitor = new Monitor(monopts)

--- a/src/services/chaintracker/BhsChainTracker.ts
+++ b/src/services/chaintracker/BhsChainTracker.ts
@@ -1,0 +1,114 @@
+import { BlockHeadersService } from '@bsv/sdk'
+import { ChaintracksServiceClient, ChaintracksServiceClientOptions } from './chaintracks/ChaintracksServiceClient'
+import { sdk } from '../../index.client'
+import { BlockHeader } from './chaintracks'
+
+export class BHServiceClient implements ChaintracksServiceClient {
+  bhs: BlockHeadersService
+  cache: Record<number, string>
+  chain: sdk.Chain
+  serviceUrl: string
+  options: ChaintracksServiceClientOptions
+
+  constructor(chain: sdk.Chain, url: string, apiKey: string) {
+    this.bhs = new BlockHeadersService(url, { apiKey })
+    this.cache = {}
+    this.chain = chain
+    this.serviceUrl = url
+    this.options = ChaintracksServiceClient.createChaintracksServiceClientOptions()
+    this.options.useAuthrite = true
+  }
+
+  async currentHeight(): Promise<number> {
+    return await this.bhs.currentHeight()
+  }
+
+  async isValidRootForHeight(root: string, height: number): Promise<boolean> {
+    const cachedRoot = this.cache[height]
+    if (cachedRoot) {
+      return cachedRoot === root
+    }
+    const isValid = await this.bhs.isValidRootForHeight(root, height)
+    this.cache[height] = root
+    return isValid
+  }
+
+  /*
+    Please note that all methods hereafter are included only to match the interface of ChaintracksServiceClient.
+    You can implement them if you need them by fetching api endpoints described in the BlockHeadersService documentation.
+  */
+
+  async getPresentHeight(): Promise<number> {
+    return await this.bhs.currentHeight()
+  }
+
+  async findHeaderForHeight(height: number): Promise<undefined> {
+    return undefined
+  }
+
+  async findHeaderForBlockHash(hash: string): Promise<undefined> {
+    return undefined
+  }
+
+  async findHeaderForMerkleRoot(merkleRoot: string, height?: number): Promise<undefined> {
+    return undefined
+  }
+
+  async getHeaders(height: number, count: number): Promise<string> {
+    return ''
+  }
+
+  async startListening(): Promise<void> {
+    return
+  }
+
+  async listening(): Promise<void> {
+    return
+  }
+
+  async isSynchronized(): Promise<boolean> {
+    return true
+  }
+
+  async getChain(): Promise<sdk.Chain> {
+    return this.chain
+  }
+
+  async isListening(): Promise<boolean> {
+    return true
+  }
+
+  async getChainTipHeader(): Promise<BlockHeader> {
+    return undefined as unknown as BlockHeader
+  }
+
+  async findChainTipHashHex(): Promise<string> {
+    return ''
+  }
+
+  async findChainWorkForBlockHash(hash: string): Promise<string | undefined> {
+    return undefined
+  }
+
+  async findChainTipHeader(): Promise<BlockHeader> {
+    return undefined as unknown as BlockHeader
+  }
+
+  async getJsonOrUndefined<T>(path: string): Promise<T | undefined> {
+    return undefined
+  }
+
+  async getJson<T>(path: string): Promise<T> {
+    return {} as T
+  }
+
+  async postJsonVoid<T>(path: string, params: T): Promise<void> {
+    return
+  }
+
+  async addHeader(header: any): Promise<void> {
+    return
+  }
+
+}
+

--- a/src/services/chaintracker/index.ts
+++ b/src/services/chaintracker/index.ts
@@ -1,2 +1,3 @@
 export * from './chaintracks'
 export * from './ChaintracksChainTracker'
+export * from './BhsChainTracker'


### PR DESCRIPTION
## Description of Changes

Ensure there is an option to rely on the open source Block Headers Service as a source of headers for SPV.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged